### PR TITLE
[Fix] VinylDto.getVinylDto()에서 vinylId 항상 null로 반환되던 버그 수정

### DIFF
--- a/src/main/java/miiiiiin/com/vinyler/application/dto/VinylDto.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/dto/VinylDto.java
@@ -70,6 +70,7 @@ public class VinylDto {
 
     private static VinylDto getVinylDto(Vinyl vinyl) {
         return VinylDto.builder()
+            .vinylId(vinyl.getVinylId())
             .discogsId(vinyl.getDiscogsId())
             .artistsSort(vinyl.getArtistsSort())
             .status(vinyl.getStatus())

--- a/src/main/java/miiiiiin/com/vinyler/user/service/UserServiceImpl.java
+++ b/src/main/java/miiiiiin/com/vinyler/user/service/UserServiceImpl.java
@@ -109,7 +109,6 @@ public class UserServiceImpl implements UserService {
     public List<VinylDto> getVinylsListenedByUser(Long userId, User currentUser) {
         var userEntity = getUserEntity(userId);
         List<UserVinylStatus> listenedVinyls = userVinylStatusRepository.findByUserAndListened(userEntity, true);
-        // TODO: FIX (USER ID?)
         return listenedVinyls.stream().map(VinylDto::of).toList();
     }
 


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #37 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- VinylDto.getVinylDto()에서 vinylId 항상 null로 반환되던 버그 수정

## 💫 타입

- [ ] 기능
- [x] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
