### PR TITLE
[Fix] User.equals()와 hashCode()에서 password 필드 제외

### DIFF
--- a/src/main/java/miiiiiin/com/vinyler/user/entity/User.java
+++ b/src/main/java/miiiiiin/com/vinyler/user/entity/User.java
@@ -55,12 +55,12 @@ public class User extends BaseEntity {
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         User user = (User) o;
-        return Objects.equals(userId, user.userId) && Objects.equals(email, user.email) && Objects.equals(password, user.password) && Objects.equals(nickname, user.nickname) && Objects.equals(deletedDate, user.deletedDate) && Objects.equals(profile, user.profile) && Objects.equals(birthday, user.birthday) && Objects.equals(followersCount, user.followersCount) && Objects.equals(followingsCount, user.followingsCount);
+        return Objects.equals(userId, user.userId) && Objects.equals(email, user.email) && Objects.equals(nickname, user.nickname) && Objects.equals(deletedDate, user.deletedDate) && Objects.equals(profile, user.profile) && Objects.equals(birthday, user.birthday) && Objects.equals(followersCount, user.followersCount) && Objects.equals(followingsCount, user.followingsCount);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId, email, password, nickname, deletedDate, profile, birthday, followersCount, followingsCount);
+        return Objects.hash(userId, email, nickname, deletedDate, profile, birthday, followersCount, followingsCount);
     }
 
     public static User of(String email, String password, String nickname, String profile, LocalDate birthday) {


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #40 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- User.equals()와 hashCode()에서 password 필드 제외
-  equals()와 hashCode()의 계약상 equals()가 true면 hashCode()도    
  같아야 하는데, 두 메서드가 다른 필드를 사용하면 HashMap, HashSet 등에서 오동작하기 때문에 둘 다 동시에 수정
- password가 equals() 비교에서 빠짐 : userId와 email만으로도 동일 유저 식별이 충분하기 때문에 password는 비교 대상에서 제외

```
수정 전 : 두 User가 같으려면 userId, email, password, nickname 등 모든 필드가 일치해야 함
수정 후 : userId, email, nickname 등 password를 제외한 나머지 필드만 일치하면 같은 User로 판단


updateReview() 작성자 검증

if (!reviewEntity.getUser().equals(currentUser)) {
    throw new UserNotAllowedException();
}

- reviewEntity.getUser() : DB에서 조회한 User -> password는 BCrypt 해시값 포함
- currentUser : UserDetailsImpl에서 꺼낸 User -> Spring Security 인증 과정에서 password가 지워져 있을 수 있음
```



## 💫 타입

- [ ] 기능
- [x] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
