### PR TITLE
[Refactor] Vinyl 엔티티에서 DTO 역의존성 제거 및 변환 로직 서비스로 이동

### DIFF
--- a/src/main/java/miiiiiin/com/vinyler/application/entity/vinyl/Vinyl.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/entity/vinyl/Vinyl.java
@@ -3,12 +3,12 @@ package miiiiiin.com.vinyler.application.entity.vinyl;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
-import miiiiiin.com.vinyler.application.dto.request.LikeRequestDto;
 import miiiiiin.com.vinyler.application.entity.Like;
 import miiiiiin.com.vinyler.user.entity.User;
 
 import java.util.ArrayList;
 import java.util.List;
+
 
 /**
  * 사용자가 좋아요를 누르면 DB에 해당 Vinyl을 저장
@@ -79,90 +79,4 @@ public class Vinyl {
     @JsonIgnore  // 직렬화 시 likes를 무시
     private List<Like> likes = new ArrayList<>();
 
-    public static Vinyl of (LikeRequestDto requestDto, User user) {
-        var vinyl = new Vinyl();
-        vinyl.setDiscogsId(requestDto.discogsId());
-        vinyl.setTitle(requestDto.title());
-        vinyl.setLikesCount(vinyl.likesCount);
-        vinyl.setArtistsSort(requestDto.artistsSort());
-        vinyl.setNotes(requestDto.notes());
-        vinyl.setReleasedFormatted(requestDto.releasedFormatted());
-        vinyl.setUri(requestDto.uri());
-        vinyl.setStatus(requestDto.status());
-
-        // 리스트 데이터 변환 및 연관 관계 설정
-        vinyl.getImages().addAll(convertDtoToImages(requestDto, vinyl));
-        vinyl.getTracklist().addAll(convertDtoToTracklist(requestDto, vinyl));
-        vinyl.getFormats().addAll(convertDtoFormats(requestDto, vinyl));
-        vinyl.getVideos().addAll(convertDtoVideos(requestDto, vinyl));
-        vinyl.getArtists().addAll(convertDtoArtists(requestDto, vinyl));
-        // Vinyl 엔티티의 현재 로그인된 유저정보로 user 세팅
-        vinyl.setUser(user);
-        return vinyl;
-    }
-    // Vinyl을 매개변수로 전달하여 연관 관계 설정
-    private static List<Image> convertDtoToImages(LikeRequestDto requestDto, Vinyl vinyl) {
-        return requestDto.images().stream()
-                .map(img -> {
-                    Image image = new Image();
-                    image.setType(img.getType());
-                    image.setUri(img.getUri());
-                    // vinyl과 연관 관계 설정
-                    image.setVinyl(vinyl);
-                    return image;
-                })
-                .toList();
-    }
-
-    private static List<TrackList> convertDtoToTracklist(LikeRequestDto requestDto, Vinyl vinyl) {
-        return requestDto.tracklist().stream()
-                .map(trackList -> {
-                    TrackList list = new TrackList();
-                    list.setTitle(trackList.getTitle());
-                    list.setDuration(trackList.getDuration());
-                    list.setPosition(trackList.getPosition());
-                    // vinyl과 연관 관계 설정
-                    list.setVinyl(vinyl);
-                    return list;
-                })
-                .toList();
-    }
-
-    private static List<Format> convertDtoFormats(LikeRequestDto requestDto, Vinyl vinyl) {
-        return requestDto.formats().stream()
-                .map(formats -> {
-                    Format format = new Format();
-                    format.setName(formats.getName());
-                    format.setDescriptions(formats.getDescriptions());
-                    // vinyl과 연관 관계 설정
-                    format.setVinyl(vinyl);
-                    return format;
-                })
-                .toList();
-    }
-
-    private static List<Video> convertDtoVideos(LikeRequestDto requestDto, Vinyl vinyl) {
-        return requestDto.videos().stream()
-                .map(vid -> {
-                    Video video = new Video();
-                    video.setUri(vid.getUri());
-                    // vinyl과 연관 관계 설정
-                    video.setVinyl(vinyl);
-                    return video;
-                })
-                .toList();
-    }
-
-    private static List<ArtistDetail> convertDtoArtists(LikeRequestDto requestDto, Vinyl vinyl) {
-        return requestDto.artists().stream()
-                .map(artists -> {
-                    ArtistDetail artist = new ArtistDetail();
-                    artist.setName(artists.getName());
-                    artist.setResourceUrl(artists.getResourceUrl());
-                    // vinyl과 연관 관계 설정
-                    artist.setVinyl(vinyl);
-                    return artist;
-                })
-                .toList();
-    }
 }

--- a/src/main/java/miiiiiin/com/vinyler/application/service/UserVinylServiceStatusImpl.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/UserVinylServiceStatusImpl.java
@@ -5,9 +5,7 @@ import lombok.RequiredArgsConstructor;
 import miiiiiin.com.vinyler.application.dto.UserVinylStatusDto;
 import miiiiiin.com.vinyler.application.dto.request.LikeRequestDto;
 import miiiiiin.com.vinyler.application.entity.UserVinylStatus;
-import miiiiiin.com.vinyler.application.entity.vinyl.Vinyl;
 import miiiiiin.com.vinyler.application.repository.UserVinylStatusRepository;
-import miiiiiin.com.vinyler.application.repository.VinylRepository;
 import miiiiiin.com.vinyler.user.entity.User;
 import org.springframework.stereotype.Service;
 
@@ -15,32 +13,22 @@ import org.springframework.stereotype.Service;
 @Service
 public class UserVinylServiceStatusImpl implements UserVinylStatusService {
 
-    private final VinylRepository vinylRepository;
+    private final VinylService vinylService;
     private final UserVinylStatusRepository userVinylStatusRepository;
 
-
-    // 사용자가 Vinyl의 감상 상태를 토글 (감상 완료/감상 미완료)
     @Override
     @Transactional
     public UserVinylStatusDto toggleListenStatus(LikeRequestDto requestDto, User currentUser) {
-        // Vinyl 엔티티가 DB에 존재하는지 확인, 없으면 저장
-        var entity = Vinyl.of(requestDto, currentUser);
-
-        var vinylEntity = vinylRepository.findByDiscogsId(entity.getDiscogsId())
-                .orElseGet(() -> {
-                    // 새로 저장할 때는 vinylId를 설정할 필요 없음 (자동 생성됨)
-                    return vinylRepository.save(entity);
-                });
+        var vinylEntity = vinylService.findOrCreateVinyl(requestDto, currentUser);
 
         var status = userVinylStatusRepository.findByUserAndVinyl(currentUser, vinylEntity);
 
         if (status.isPresent() && status.get().isListened()) {
             userVinylStatusRepository.delete(status.get());
-            return UserVinylStatusDto.from(vinylRepository.save(vinylEntity), currentUser, false);
+            return UserVinylStatusDto.from(vinylEntity, currentUser, false);
         } else {
-            var st = UserVinylStatus.of(currentUser, vinylEntity, true);
-            userVinylStatusRepository.save(st);
-            return UserVinylStatusDto.from(vinylRepository.save(vinylEntity), currentUser, true);
+            userVinylStatusRepository.save(UserVinylStatus.of(currentUser, vinylEntity, true));
+            return UserVinylStatusDto.from(vinylEntity, currentUser, true);
         }
     }
 }

--- a/src/main/java/miiiiiin/com/vinyler/application/service/VinylService.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/VinylService.java
@@ -2,9 +2,11 @@ package miiiiiin.com.vinyler.application.service;
 
 import miiiiiin.com.vinyler.application.dto.VinylLikeDto;
 import miiiiiin.com.vinyler.application.dto.request.LikeRequestDto;
+import miiiiiin.com.vinyler.application.entity.vinyl.Vinyl;
 import miiiiiin.com.vinyler.user.entity.User;
 
 public interface VinylService {
     VinylLikeDto toggleLike(LikeRequestDto requestDto, User user);
     VinylLikeDto getLikeStatus(Long discogsId, User currentUser);
+    Vinyl findOrCreateVinyl(LikeRequestDto requestDto, User user);
 }

--- a/src/main/java/miiiiiin/com/vinyler/application/service/VinylServiceImpl.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/VinylServiceImpl.java
@@ -4,6 +4,11 @@ import lombok.RequiredArgsConstructor;
 import miiiiiin.com.vinyler.application.dto.VinylLikeDto;
 import miiiiiin.com.vinyler.application.dto.request.LikeRequestDto;
 import miiiiiin.com.vinyler.application.entity.Like;
+import miiiiiin.com.vinyler.application.entity.vinyl.ArtistDetail;
+import miiiiiin.com.vinyler.application.entity.vinyl.Format;
+import miiiiiin.com.vinyler.application.entity.vinyl.Image;
+import miiiiiin.com.vinyler.application.entity.vinyl.TrackList;
+import miiiiiin.com.vinyler.application.entity.vinyl.Video;
 import miiiiiin.com.vinyler.application.entity.vinyl.Vinyl;
 import miiiiiin.com.vinyler.application.repository.LikeRepository;
 import miiiiiin.com.vinyler.application.repository.VinylRepository;
@@ -21,15 +26,15 @@ public class VinylServiceImpl implements VinylService {
 
     @Override
     @Transactional
-    public VinylLikeDto toggleLike(LikeRequestDto requestDto, User currentUser) {
-        // Vinyl 엔티티가 DB에 존재하는지 확인, 없으면 저장
-        var entity = Vinyl.of(requestDto, currentUser);
+    public Vinyl findOrCreateVinyl(LikeRequestDto requestDto, User user) {
+        return vinylRepository.findByDiscogsId(requestDto.discogsId())
+                .orElseGet(() -> vinylRepository.save(buildVinylFromDto(requestDto, user)));
+    }
 
-        var vinylEntity = vinylRepository.findByDiscogsId(entity.getDiscogsId())
-                .orElseGet(() -> {
-                    // 새로 저장할 때는 vinylId를 설정할 필요 없음 (자동 생성됨)
-                    return vinylRepository.save(entity);
-                });
+    @Override
+    @Transactional
+    public VinylLikeDto toggleLike(LikeRequestDto requestDto, User currentUser) {
+        var vinylEntity = findOrCreateVinyl(requestDto, currentUser);
 
         // 사용자와 Vinyl에 대한 Like 조회
         var likeEntity = likeRepository.findByUserAndVinyl(currentUser, vinylEntity);
@@ -43,6 +48,37 @@ public class VinylServiceImpl implements VinylService {
             vinylEntity.setLikesCount(vinylEntity.getLikesCount() + 1);
             return VinylLikeDto.from(vinylRepository.save(vinylEntity), currentUser, true);
         }
+    }
+
+    private Vinyl buildVinylFromDto(LikeRequestDto requestDto, User user) {
+        var vinyl = new Vinyl();
+        vinyl.setDiscogsId(requestDto.discogsId());
+        vinyl.setTitle(requestDto.title());
+        vinyl.setLikesCount(0L);
+        vinyl.setArtistsSort(requestDto.artistsSort());
+        vinyl.setNotes(requestDto.notes());
+        vinyl.setReleasedFormatted(requestDto.releasedFormatted());
+        vinyl.setUri(requestDto.uri());
+        vinyl.setStatus(requestDto.status());
+        vinyl.setUser(user);
+
+        vinyl.getImages().addAll(requestDto.images().stream()
+                .map(img -> { Image i = new Image(); i.setType(img.getType()); i.setUri(img.getUri()); i.setVinyl(vinyl); return i; })
+                .toList());
+        vinyl.getTracklist().addAll(requestDto.tracklist().stream()
+                .map(t -> { TrackList tl = new TrackList(); tl.setTitle(t.getTitle()); tl.setDuration(t.getDuration()); tl.setPosition(t.getPosition()); tl.setVinyl(vinyl); return tl; })
+                .toList());
+        vinyl.getFormats().addAll(requestDto.formats().stream()
+                .map(f -> { Format fmt = new Format(); fmt.setName(f.getName()); fmt.setDescriptions(f.getDescriptions()); fmt.setVinyl(vinyl); return fmt; })
+                .toList());
+        vinyl.getVideos().addAll(requestDto.videos().stream()
+                .map(v -> { Video vid = new Video(); vid.setUri(v.getUri()); vid.setVinyl(vinyl); return vid; })
+                .toList());
+        vinyl.getArtists().addAll(requestDto.artists().stream()
+                .map(a -> { ArtistDetail art = new ArtistDetail(); art.setName(a.getName()); art.setResourceUrl(a.getResourceUrl()); art.setVinyl(vinyl); return art; })
+                .toList());
+
+        return vinyl;
     }
 
     @Override


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #43 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- Vinyl 엔티티가 LikeRequestDto를 직접 참조하는 구조로 인해 도메인 레이어가 DTO 레이어에 역으로 의존하는 레이어 위반 현상 수정
- 정적 팩토리 메서드 및 내부 변환 헬퍼 메서드 제거
- DTO -> 엔티티 변환 로직을 VinylServiceImpl.buildVinylFromDto()로 이동   

## 테스트 방법
Swagger에서 확인할 시나리오:
1. 로그인 -> Access Token 획득
2. 새 Vinyl(DB에 없는 discogsId)로 찜 API 호출 -> Vinyl이 DB에 생성되는지
3. 동일 Vinyl 다시 찜 -> 토글(찜 취소)이 되는지
4. 감상 상태 토글 API 동일하게 확인

## 💫 타입

- [ ] 기능
- [ ] 버그
- [x] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
