### PR TITLE
[Feat] 유저 정보 수정 API

### DIFF
--- a/src/main/java/miiiiiin/com/vinyler/user/controller/UserController.java
+++ b/src/main/java/miiiiiin/com/vinyler/user/controller/UserController.java
@@ -13,6 +13,7 @@ import miiiiiin.com.vinyler.security.UserDetailsImpl;
 import miiiiiin.com.vinyler.user.dto.ServiceRegisterDto;
 import miiiiiin.com.vinyler.user.dto.UserDto;
 import miiiiiin.com.vinyler.user.dto.request.ClientRegisterReqeustDto;
+import miiiiiin.com.vinyler.user.dto.request.UpdateUserRequestDto;
 import miiiiiin.com.vinyler.user.dto.response.UserResponseDto;
 import miiiiiin.com.vinyler.user.service.UserService;
 import org.springframework.http.HttpStatus;
@@ -143,4 +144,19 @@ public class UserController {
         var response = userService.getUserInfo(userDetails.getUser());
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
+
+    @PatchMapping
+    @Operation(summary = "내 정보 수정", description = "현재 로그인한 사용자의 정보를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 닉네임")
+    })
+    public ResponseEntity<UserDto> updateUserInfo(
+            @RequestBody UpdateUserRequestDto request,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        var response = userService.updateUserInfo(userDetails.getUser(), request);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
 }

--- a/src/main/java/miiiiiin/com/vinyler/user/dto/request/UpdateUserRequestDto.java
+++ b/src/main/java/miiiiiin/com/vinyler/user/dto/request/UpdateUserRequestDto.java
@@ -1,0 +1,15 @@
+package miiiiiin.com.vinyler.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import miiiiiin.com.vinyler.user.enums.ProfileVisibility;
+
+import java.time.LocalDate;
+
+@Schema(description = "유저 정보 수정")
+public record UpdateUserRequestDto(
+        @Schema(description = "닉네임", example = "바이닐러") String nickname,
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg") String profile,
+        @Schema(description = "생년월일", example = "2005-06-15") LocalDate birthday,
+        @Schema(description = "프로필 공개 범위", example = "PUBLIC") ProfileVisibility visibility
+) {
+}

--- a/src/main/java/miiiiiin/com/vinyler/user/service/UserService.java
+++ b/src/main/java/miiiiiin/com/vinyler/user/service/UserService.java
@@ -1,17 +1,12 @@
 package miiiiiin.com.vinyler.user.service;
 
-import jakarta.validation.Valid;
 import miiiiiin.com.vinyler.application.dto.VinylDto;
 import miiiiiin.com.vinyler.application.dto.response.SliceResponse;
 import miiiiiin.com.vinyler.user.dto.ServiceRegisterDto;
 import miiiiiin.com.vinyler.user.dto.UserDto;
-import miiiiiin.com.vinyler.user.dto.request.LoginRequestDto;
-import miiiiiin.com.vinyler.user.dto.response.LoginResponseDto;
+import miiiiiin.com.vinyler.user.dto.request.UpdateUserRequestDto;
 import miiiiiin.com.vinyler.user.dto.response.UserResponseDto;
 import miiiiiin.com.vinyler.user.entity.User;
-import miiiiiin.com.vinyler.user.enums.ProfileVisibility;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
 import java.util.List;
@@ -25,6 +20,5 @@ public interface UserService extends UserDetailsService {
     List<UserDto> getFollowersByUser(Long userId, User user);
     List<UserDto> getFollowingsByUser(Long userId, User user);
     UserDto getUserInfo(User user);
-
-    UserDto changeProfileVisibility(User currentUser, ProfileVisibility visibility);
+    UserDto updateUserInfo(User currentUser, UpdateUserRequestDto dto);
 }

--- a/src/main/java/miiiiiin/com/vinyler/user/service/UserServiceImpl.java
+++ b/src/main/java/miiiiiin/com/vinyler/user/service/UserServiceImpl.java
@@ -23,6 +23,7 @@ import miiiiiin.com.vinyler.global.Constants;
 import miiiiiin.com.vinyler.security.UserDetailsImpl;
 import miiiiiin.com.vinyler.user.dto.ServiceRegisterDto;
 import miiiiiin.com.vinyler.user.dto.UserDto;
+import miiiiiin.com.vinyler.user.dto.request.UpdateUserRequestDto;
 import miiiiiin.com.vinyler.user.dto.response.UserResponseDto;
 import miiiiiin.com.vinyler.user.entity.User;
 import miiiiiin.com.vinyler.user.enums.ProfileVisibility;
@@ -57,6 +58,24 @@ public class UserServiceImpl implements UserService {
     @Override
     public UserDto getUserInfo(User currentUser) {
         return UserDto.from(currentUser, false);
+    }
+
+    @Override
+    @Transactional
+    public UserDto updateUserInfo(User currentUser, UpdateUserRequestDto dto) {
+        if (dto.nickname() != null && !dto.nickname().equals(currentUser.getNickname())) {
+            userRepository.findByNickname(dto.nickname()).ifPresent(
+                    u -> { throw new UserAlreadyExistException(dto.nickname());});
+            currentUser.setNickname(dto.nickname());
+        }
+
+        if (dto.profile() != null) currentUser.setProfile(dto.profile());
+        if (dto.birthday() != null) currentUser.setBirthday(dto.birthday());
+        if (dto.visibility() != null) currentUser.setVisibility(dto.visibility());
+
+        // SecurityContext에서 넘어온 엔티티는 detached 상태일 수 있으므로 명시적으로 저장
+        userRepository.save(currentUser);
+        return getUserInfo(currentUser);
     }
 
     @Override
@@ -187,18 +206,6 @@ public class UserServiceImpl implements UserService {
         var follower = getUserEntity(userId);
         var followEntities = followRepository.findByFollower(follower);
         return followEntities.stream().map(follow -> getUserWithFollowingStatus(currentUser, follow.getFollowing())).toList();
-    }
-
-    /**
-     * 사용자의 프로필 공개 여부 변경
-     */
-    @Override
-    @Transactional
-    public UserDto changeProfileVisibility(User currentUser, ProfileVisibility visibility) {
-        currentUser.setVisibility(visibility);
-        // SecurityContext에서 넘어온 엔티티는 detached 상태일 수 있으므로 명시적으로 저장
-        userRepository.save(currentUser);
-        return getUserInfo(currentUser);
     }
 
     /**

--- a/src/test/java/miiiiiin/com/vinyler/user/service/UserServiceImplTest.java
+++ b/src/test/java/miiiiiin/com/vinyler/user/service/UserServiceImplTest.java
@@ -19,7 +19,9 @@ import miiiiiin.com.vinyler.security.UserDetailsImpl;
 import miiiiiin.com.vinyler.user.dto.ServiceRegisterDto;
 import miiiiiin.com.vinyler.user.dto.UserDto;
 import miiiiiin.com.vinyler.user.dto.response.UserResponseDto;
+import miiiiiin.com.vinyler.user.dto.request.UpdateUserRequestDto;
 import miiiiiin.com.vinyler.user.entity.User;
+import miiiiiin.com.vinyler.user.enums.ProfileVisibility;
 import miiiiiin.com.vinyler.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -180,7 +182,74 @@ class UserServiceImplTest {
         assertThat(result).isNotNull();
         assertThat(result.getEmail()).isEqualTo(testUser.getEmail());
         assertThat(result.getNickname()).isEqualTo(testUser.getNickname());
+        assertThat(result.getVisibility()).isEqualTo(ProfileVisibility.PUBLIC);
         assertThat(result.isFollowing()).isFalse();
+    }
+
+    @Test
+    @DisplayName("유저 정보 수정 - 전체 필드 성공")
+    void updateUserInfo_AllFields_Success() {
+        // Given
+        UpdateUserRequestDto dto = new UpdateUserRequestDto(
+                "newnickname", "newprofile.jpg", LocalDate.of(1995, 5, 15), ProfileVisibility.PRIVATE
+        );
+        when(userRepository.findByNickname("newnickname")).thenReturn(Optional.empty());
+        when(userRepository.save(testUser)).thenReturn(testUser);
+
+        // When
+        UserDto result = userService.updateUserInfo(testUser, dto);
+
+        // Then
+        assertThat(result.getNickname()).isEqualTo("newnickname");
+        assertThat(result.getProfile()).isEqualTo("newprofile.jpg");
+        assertThat(result.getBirthday()).isEqualTo(LocalDate.of(1995, 5, 15));
+        assertThat(result.getVisibility()).isEqualTo(ProfileVisibility.PRIVATE);
+        verify(userRepository).save(testUser);
+    }
+
+    @Test
+    @DisplayName("유저 정보 수정 - 현재 닉네임과 동일하면 중복 체크 없음")
+    void updateUserInfo_SameNickname_NoCheck() {
+        // Given
+        UpdateUserRequestDto dto = new UpdateUserRequestDto("testuser", null, null, null);
+        when(userRepository.save(testUser)).thenReturn(testUser);
+
+        // When
+        userService.updateUserInfo(testUser, dto);
+
+        // Then
+        verify(userRepository, never()).findByNickname(any());
+        verify(userRepository).save(testUser);
+    }
+
+    @Test
+    @DisplayName("유저 정보 수정 - 닉네임 중복 시 예외 발생")
+    void updateUserInfo_NicknameDuplicate_ThrowsException() {
+        // Given
+        UpdateUserRequestDto dto = new UpdateUserRequestDto("duplicatenick", null, null, null);
+        when(userRepository.findByNickname("duplicatenick")).thenReturn(Optional.of(anotherUser));
+
+        // When & Then
+        assertThatThrownBy(() -> userService.updateUserInfo(testUser, dto))
+                .isInstanceOf(UserAlreadyExistException.class);
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("유저 정보 수정 - null 필드는 변경 없음")
+    void updateUserInfo_NullFields_NoChange() {
+        // Given
+        UpdateUserRequestDto dto = new UpdateUserRequestDto(null, null, null, null);
+        String originalNickname = testUser.getNickname();
+        when(userRepository.save(testUser)).thenReturn(testUser);
+
+        // When
+        UserDto result = userService.updateUserInfo(testUser, dto);
+
+        // Then
+        assertThat(result.getNickname()).isEqualTo(originalNickname);
+        verify(userRepository, never()).findByNickname(any());
+        verify(userRepository).save(testUser);
     }
 
     @Test
@@ -316,7 +385,7 @@ class UserServiceImplTest {
         Follow follow2 = Follow.of(testUser, thirdUser);
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(followRepository.findByFollowing(testUser)).thenReturn(Arrays.asList(follow1, follow2));
+        when(followRepository.findByFollower(testUser)).thenReturn(Arrays.asList(follow1, follow2));
         when(followRepository.findByFollowerAndFollowing(eq(testUser), any())).thenReturn(Optional.empty());
 
         // When


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #45 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- UpdateUserRequestDto record 추가 (nickname, profile, birthday, visibility)
- 엔드포인트 구현
- nickname 수정 시 본인 제외 중복 체크 적용
- 테스트 코드 갱신 및 수정


## 💫 타입

- [x] 기능
- [ ] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
