### PR TITLE
[Refactor] 유저 감상 LP 목록 커서 기반 페이징 적용

### DIFF
--- a/src/main/java/miiiiiin/com/vinyler/application/dto/UserVinylStatusDto.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/dto/UserVinylStatusDto.java
@@ -3,9 +3,11 @@ package miiiiiin.com.vinyler.application.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import lombok.Getter;
 import miiiiiin.com.vinyler.application.entity.vinyl.Vinyl;
 import miiiiiin.com.vinyler.user.entity.User;
 
+@Getter
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Vinyl 감상 상태 응답")

--- a/src/main/java/miiiiiin/com/vinyler/application/repository/UserVinylStatusRepository.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/repository/UserVinylStatusRepository.java
@@ -3,7 +3,10 @@ package miiiiiin.com.vinyler.application.repository;
 import miiiiiin.com.vinyler.application.entity.UserVinylStatus;
 import miiiiiin.com.vinyler.application.entity.vinyl.Vinyl;
 import miiiiiin.com.vinyler.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,4 +17,19 @@ public interface UserVinylStatusRepository extends JpaRepository<UserVinylStatus
     Optional<UserVinylStatus> findByUserAndVinyl(User user, Vinyl vinyl);
     // 특정 사용자가 감상한 LP들을 조회
     List<UserVinylStatus> findByUserAndListened(User user, boolean listened);
+
+
+    @Query("""
+        SELECT uvs 
+        FROM UserVinylStatus uvs      
+        WHERE uvs.user = :user
+        AND uvs.listened = true
+        AND (:cursorId IS NULL OR uvs.id < :cursorId)
+        ORDER BY uvs.id DESC
+      """
+    )
+    List<UserVinylStatus> findListenedByUserWithCursor(@Param("user") User user, @Param("cursorId") Long cursorId, Pageable pageable);
+
+
+
 }

--- a/src/main/java/miiiiiin/com/vinyler/user/controller/UserController.java
+++ b/src/main/java/miiiiiin/com/vinyler/user/controller/UserController.java
@@ -64,17 +64,19 @@ public class UserController {
     }
 
     @GetMapping("/{userId}/listened")
-    @Operation(summary = "감상한 Vinyl 목록 조회", description = "특정 유저가 감상한 Vinyl 목록을 조회합니다.")
+    @Operation(summary = "감상한 Vinyl 목록 조회", description = "특정 유저가 감상한 Vinyl 목록을 커서 기반 페이징으로 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증 실패"),
             @ApiResponse(responseCode = "403", description = "접근 권한 없음"),
             @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음")
     })
-    public ResponseEntity<List<VinylDto>> getVinylsListenedByUser(
+    public ResponseEntity<SliceResponse<VinylDto>> getVinylsListenedByUser(
             @Parameter(description = "조회할 유저 ID", example = "1") @PathVariable Long userId,
-            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        var response = userService.getVinylsListenedByUser(userId, userDetails.getUser());
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "커서 ID (다음 페이지 시작점, 첫 요청 시 생략)") @RequestParam(required = false) Long cursorId,
+            @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size) {
+        var response = userService.getVinylsListenedByUser(userId, userDetails.getUser(), cursorId, size);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/miiiiiin/com/vinyler/user/service/UserService.java
+++ b/src/main/java/miiiiiin/com/vinyler/user/service/UserService.java
@@ -14,7 +14,7 @@ import java.util.List;
 public interface UserService extends UserDetailsService {
     UserResponseDto registerUser(ServiceRegisterDto dto);
     SliceResponse<VinylDto> getVinylsLikedByUser(Long userId, User user, Long cursorId, int size);
-    List<VinylDto> getVinylsListenedByUser(Long userId, User user);
+    SliceResponse<VinylDto> getVinylsListenedByUser(Long userId, User user, Long cursorId, int size);
     UserDto follow(Long userId, User user);
     UserDto unfollow(Long userId, User user);
     List<UserDto> getFollowersByUser(Long userId, User user);
@@ -23,4 +23,5 @@ public interface UserService extends UserDetailsService {
     UserDto updateUserInfo(User currentUser, UpdateUserRequestDto dto);
 
     void withdrawUser(User currentUser);
+
 }

--- a/src/main/java/miiiiiin/com/vinyler/user/service/UserServiceImpl.java
+++ b/src/main/java/miiiiiin/com/vinyler/user/service/UserServiceImpl.java
@@ -1,6 +1,5 @@
 package miiiiiin.com.vinyler.user.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import miiiiiin.com.vinyler.application.dto.VinylDto;
 import miiiiiin.com.vinyler.application.dto.projection.LikeVinylProjection;
@@ -35,8 +34,10 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -131,12 +132,31 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public List<VinylDto> getVinylsListenedByUser(Long userId, User currentUser) {
+    public SliceResponse<VinylDto> getVinylsListenedByUser(Long userId, User currentUser, Long cursorId, int size) {
+        // 커서 페이징 size + 1 (+1로 다음 페이지(hasNext) 존재 여부 판단)
+        Pageable pageable = PageRequest.of(0, size + 1);
+
         var targetUser = getUserEntity(userId);
+
         // 접근 가능 여부 확인
         validateVisibility(targetUser, currentUser);
-        List<UserVinylStatus> listenedVinyls = userVinylStatusRepository.findByUserAndListened(targetUser, true);
-        return listenedVinyls.stream().map(VinylDto::of).toList();
+
+        List<UserVinylStatus> results = userVinylStatusRepository.findListenedByUserWithCursor(targetUser, cursorId, pageable);
+        // 결과가 size보다 많다는 의미
+        boolean hasNext = results.size() > size;
+        // 마지막 1개를 제외한 size개만 클라이언트에 응답 => subList(0, size)를 이용해 앞쪽 size개만 자름
+        List<UserVinylStatus> contents = hasNext ? results.subList(0, size) : results;
+
+        // 필요한 연관 관계 직접 조회 및 VinylDto로 구성 (유저가 감상한 음반 목록 조회)
+        List<VinylDto> vinylDtos = contents.stream()
+                .map(VinylDto::of)
+                .toList();
+
+        // 다음 요청에서 커서로 사용할 ID = 클라이언트에 반환해준 마지막 요소의 ID (contents.get(last))
+        Long nextCursorId = hasNext ? contents.get(contents.size() - 1).getId() : null;
+
+        SliceImpl<VinylDto> sliceContents = new SliceImpl<>(vinylDtos, PageRequest.of(0, size), hasNext);
+        return new SliceResponse<>(sliceContents, nextCursorId);
     }
 
     @Override

--- a/src/test/java/miiiiiin/com/vinyler/application/service/VinylServiceImplTest.java
+++ b/src/test/java/miiiiiin/com/vinyler/application/service/VinylServiceImplTest.java
@@ -94,7 +94,7 @@ class VinylServiceImplTest {
 
         // Then
         assertThat(result).isNotNull();
-        assertThat(result.isIsLiking()).isTrue();
+        assertThat(result.isLiking()).isTrue();
         assertThat(result.getVinylId()).isEqualTo(1L);
         assertThat(result.getUserId()).isEqualTo(1L);
         assertThat(testVinyl.getLikesCount()).isEqualTo(6L);
@@ -116,7 +116,7 @@ class VinylServiceImplTest {
 
         // Then
         assertThat(result).isNotNull();
-        assertThat(result.isIsLiking()).isTrue();
+        assertThat(result.isLiking()).isTrue();
         verify(vinylRepository, times(2)).save(any(Vinyl.class)); // 한 번은 생성, 한 번은 likesCount 업데이트
         verify(likeRepository, times(1)).save(any(Like.class));
     }
@@ -134,7 +134,7 @@ class VinylServiceImplTest {
 
         // Then
         assertThat(result).isNotNull();
-        assertThat(result.isIsLiking()).isFalse();
+        assertThat(result.isLiking()).isFalse();
         assertThat(testVinyl.getLikesCount()).isEqualTo(4L);
         verify(likeRepository, times(1)).delete(testLike);
         verify(vinylRepository, times(1)).save(testVinyl);
@@ -154,7 +154,7 @@ class VinylServiceImplTest {
 
         // Then
         assertThat(testVinyl.getLikesCount()).isEqualTo(0L);
-        assertThat(result.isIsLiking()).isFalse();
+        assertThat(result.isLiking()).isFalse();
     }
 
     @Test
@@ -169,7 +169,7 @@ class VinylServiceImplTest {
 
         // Then
         assertThat(result).isNotNull();
-        assertThat(result.isIsLiking()).isTrue();
+        assertThat(result.isLiking()).isTrue();
         assertThat(result.getVinylId()).isEqualTo(1L);
         assertThat(result.getUserId()).isEqualTo(1L);
         verify(vinylRepository, times(1)).findByDiscogsId(12345L);
@@ -188,7 +188,7 @@ class VinylServiceImplTest {
 
         // Then
         assertThat(result).isNotNull();
-        assertThat(result.isIsLiking()).isFalse();
+        assertThat(result.isLiking()).isFalse();
         verify(vinylRepository, times(1)).findByDiscogsId(12345L);
         verify(likeRepository, times(1)).findByUserAndVinyl(testUser, testVinyl);
     }

--- a/src/test/java/miiiiiin/com/vinyler/user/service/UserServiceImplTest.java
+++ b/src/test/java/miiiiiin/com/vinyler/user/service/UserServiceImplTest.java
@@ -429,6 +429,8 @@ class UserServiceImplTest {
     @DisplayName("사용자가 감상한 Vinyl 목록 조회 - 성공")
     void getVinylsListenedByUser_Success() {
         // Given
+        Long cursorId = null;
+        int size = 2;
         Vinyl vinyl1 = Vinyl.builder().vinylId(1L).discogsId(100L).title("Vinyl 1")
                 .images(new ArrayList<>()).tracklist(new ArrayList<>()).formats(new ArrayList<>())
                 .videos(new ArrayList<>()).artists(new ArrayList<>()).build();
@@ -436,14 +438,15 @@ class UserServiceImplTest {
         UserVinylStatus status1 = UserVinylStatus.of(testUser, vinyl1, true);
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(userVinylStatusRepository.findByUserAndListened(testUser, true))
+        when(userVinylStatusRepository.findListenedByUserWithCursor(eq(testUser), isNull(), any()))
                 .thenReturn(List.of(status1));
 
         // When
-        List<VinylDto> result = userService.getVinylsListenedByUser(1L, testUser);
+        SliceResponse<VinylDto> result = userService.getVinylsListenedByUser(1L, testUser, cursorId, size);
 
         // Then
-        assertThat(result).hasSize(1);
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.isHasNext()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #48 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- 유저 감상 LP 목록 커서 기반 페이징 적용 (기존에는 전체 목록 조회였음)

## 💫 타입

- [ ] 기능
- [ ] 버그
- [x] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
