### PR TITLE
[Refactor] 팔로워/팔로잉 목록 커서 기반 페이징 적용

### DIFF
--- a/src/main/java/miiiiiin/com/vinyler/application/repository/FollowRepository.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/repository/FollowRepository.java
@@ -2,7 +2,10 @@ package miiiiiin.com.vinyler.application.repository;
 
 import miiiiiin.com.vinyler.application.entity.Follow;
 import miiiiiin.com.vinyler.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,12 +14,33 @@ import java.util.Optional;
 @Repository
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
-    /** 특정 유저가 팔로우하고 있는 관계 목록 조회 (내가 팔로우한 사람들) */
-    List<Follow> findByFollower(User follower);
-
-    /** 특정 유저를 팔로우하고 있는 관계 목록 조회 (나를 팔로우한 사람들) */
-    List<Follow> findByFollowing(User following);
+//    /** 특정 유저가 팔로우하고 있는 관계 목록 조회 (내가 팔로우한 사람들) */
+//    List<Follow> findByFollower(User follower);
+//
+//    /** 특정 유저를 팔로우하고 있는 관계 목록 조회 (나를 팔로우한 사람들) */
+//    List<Follow> findByFollowing(User following);
 
     /** 팔로워 → 팔로잉 관계가 존재하는지 조회 (팔로우 여부 확인 및 언팔로우 시 사용) */
     Optional<Follow> findByFollowerAndFollowing(User follower, User following);
+
+    /** 특정 유저를 팔로우하고 있는 관계 목록 조회 / 팔로워 목록 (나를 팔로우한 사람들) */
+    @Query("""
+      SELECT f
+      FROM Follow f
+      WHERE f.following = :user
+      AND (:cursorId IS NULL OR f.id < :cursorId)
+      ORDER BY f.id DESC
+      """
+    )
+    List<Follow> findFollowersByUserWithCursor(@Param("user") User user, @Param("cursorId") Long cursorId, Pageable pageable);
+
+    /** 특정 유저가 팔로우하고 있는 관계 목록 조회 / 팔로잉 목록 (내가 팔로우한 사람들) */
+    @Query("""
+        SELECT f
+        FROM Follow f
+        WHERE f.follower = :user
+        AND (:cursorId IS NULL OR f.id < :cursorId)
+        ORDER BY f.id DESC
+    """)
+    List<Follow> findFollowingsByUserWithCursor(@Param("user") User user, @Param("cursorId") Long cursorId, Pageable pageable);
 }

--- a/src/main/java/miiiiiin/com/vinyler/user/controller/UserController.java
+++ b/src/main/java/miiiiiin/com/vinyler/user/controller/UserController.java
@@ -117,10 +117,12 @@ public class UserController {
             @ApiResponse(responseCode = "401", description = "인증 실패"),
             @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음")
     })
-    public ResponseEntity<List<UserDto>> getFollowersByUser(
+    public ResponseEntity<SliceResponse<UserDto>> getFollowersByUser(
             @Parameter(description = "조회할 유저 ID", example = "1") @PathVariable Long userId,
-            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        var response = userService.getFollowersByUser(userId, userDetails.getUser());
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "커서 ID (다음 페이지 시작점, 첫 요청 시 생략)") @RequestParam(required = false) Long cursorId,
+            @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size) {
+        var response = userService.getFollowersByUser(userId, userDetails.getUser(), cursorId, size);
         return ResponseEntity.ok(response);
     }
 
@@ -131,10 +133,12 @@ public class UserController {
             @ApiResponse(responseCode = "401", description = "인증 실패"),
             @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음")
     })
-    public ResponseEntity<List<UserDto>> getFollowingsByUser(
+    public ResponseEntity<SliceResponse<UserDto>> getFollowingsByUser(
             @Parameter(description = "조회할 유저 ID", example = "1") @PathVariable Long userId,
-            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        var response = userService.getFollowingsByUser(userId, userDetails.getUser());
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "커서 ID (다음 페이지 시작점, 첫 요청 시 생략)") @RequestParam(required = false) Long cursorId,
+            @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size) {
+        var response = userService.getFollowingsByUser(userId, userDetails.getUser(), cursorId, size);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/miiiiiin/com/vinyler/user/service/UserService.java
+++ b/src/main/java/miiiiiin/com/vinyler/user/service/UserService.java
@@ -17,8 +17,8 @@ public interface UserService extends UserDetailsService {
     SliceResponse<VinylDto> getVinylsListenedByUser(Long userId, User user, Long cursorId, int size);
     UserDto follow(Long userId, User user);
     UserDto unfollow(Long userId, User user);
-    List<UserDto> getFollowersByUser(Long userId, User user);
-    List<UserDto> getFollowingsByUser(Long userId, User user);
+    SliceResponse<UserDto> getFollowersByUser(Long userId, User user, Long cursorId, int size);
+    SliceResponse<UserDto> getFollowingsByUser(Long userId, User user, Long cursorId, int size);
     UserDto getUserInfo(User user);
     UserDto updateUserInfo(User currentUser, UpdateUserRequestDto dto);
 

--- a/src/main/java/miiiiiin/com/vinyler/user/service/UserServiceImpl.java
+++ b/src/main/java/miiiiiin/com/vinyler/user/service/UserServiceImpl.java
@@ -159,6 +159,74 @@ public class UserServiceImpl implements UserService {
         return new SliceResponse<>(sliceContents, nextCursorId);
     }
 
+
+
+    /**
+     * userId의 팔로워 리스트
+     * 나를 팔로우한 사람들 (팔로워 목록)
+     */
+    @Override
+    public SliceResponse<UserDto> getFollowersByUser(Long userId, User currentUser, Long cursorId, int size) {
+        // 커서 페이징 size + 1 (+1로 다음 페이지(hasNext) 존재 여부 판단)
+        Pageable pageable = PageRequest.of(0, size + 1);
+
+        // 팔로잉하고 있는 해당 유저 존재하는지 확인 (팔로워 목록을 조회할 대상 유저)
+        var targetUser = getUserEntity(userId);
+
+        // targetUser를 팔로우하고 있는 Follow 행들을 커서 기반으로 조회
+        List<Follow> results = followRepository.findFollowersByUserWithCursor(targetUser, cursorId, pageable);
+
+        // 결과가 size보다 많다는 의미
+        boolean hasNext = results.size() > size;
+        // 마지막 1개를 제외한 size개만 클라이언트에 응답 => subList(0, size)를 이용해 앞쪽 size개만 자름
+        List<Follow> contents = hasNext ? results.subList(0, size) : results;
+
+        // follow.getFollower() : 실제 팔로워 유저
+        // (currentUser가 각 팔로워를 팔로우하고 있는지 isFollowing 체크 포함)
+        List<UserDto> userDtos = contents.stream()
+                .map(follow -> getUserWithFollowingStatus(currentUser, follow.getFollower()))
+                .toList();
+
+        // 다음 요청에서 커서로 사용할 ID = 클라이언트에 반환해준 마지막 요소의 ID (contents.get(last)) : Follow.id
+        Long nextCursorId = hasNext ? contents.get(contents.size() - 1).getId() : null;
+
+        SliceImpl<UserDto> sliceContents = new SliceImpl<>(userDtos, PageRequest.of(0, size), hasNext);
+        return new SliceResponse<>(sliceContents, nextCursorId);
+    }
+
+    /**
+     * userId가 팔로워 (userId가 팔로잉하고 있는 리스트)
+     * 내가 팔로우한 사람들 (팔로잉 목록)
+     */
+    @Override
+    public SliceResponse<UserDto> getFollowingsByUser(Long userId, User currentUser, Long cursorId, int size) {
+        // 커서 페이징 size + 1 (+1로 다음 페이지(hasNext) 존재 여부 판단)
+        Pageable pageable = PageRequest.of(0, size + 1);
+
+        // 팔로잉하고 있는 해당 유저 존재하는지 확인 (팔로워 목록을 조회할 대상 유저)
+        var targetUser = getUserEntity(userId);
+
+        // targetUser가 팔로잉하고있는 Follow 행들을 커서 기반으로 조회
+        List<Follow> results = followRepository.findFollowingsByUserWithCursor(targetUser, cursorId, pageable);
+
+        // 결과가 size보다 많다는 의미
+        boolean hasNext = results.size() > size;
+        // 마지막 1개를 제외한 size개만 클라이언트에 응답 => subList(0, size)를 이용해 앞쪽 size개만 자름
+        List<Follow> contents = hasNext ? results.subList(0, size) : results;
+
+        // follow.getFollowing : targetUser(나)가 팔로우한 유저
+        // (currentUser가 각 팔로워를 팔로우하고 있는지 isFollowing 체크 포함)
+        List<UserDto> userDtos = contents.stream()
+                .map(follow -> getUserWithFollowingStatus(currentUser, follow.getFollowing()))
+                .toList();
+
+        // 다음 요청에서 커서로 사용할 ID = 클라이언트에 반환해준 마지막 요소의 ID (contents.get(last)) : Follow.id
+        Long nextCursorId = hasNext ? contents.get(contents.size() - 1).getId() : null;
+
+        SliceImpl<UserDto> sliceContents = new SliceImpl<>(userDtos, PageRequest.of(0, size), hasNext);
+        return new SliceResponse<>(sliceContents, nextCursorId);
+    }
+
     @Override
     public UserDto follow(Long userId, User currentUser) {
         var following = getUserEntity(userId);
@@ -203,29 +271,6 @@ public class UserServiceImpl implements UserService {
 
         userRepository.saveAll(List.of(currentUser, following));
         return UserDto.from(following, false);
-    }
-
-    /**
-     * userId의 팔로워 리스트
-     * 나를 팔로우한 사람들 (팔로워 목록)
-     */
-    @Override
-    public List<UserDto> getFollowersByUser(Long userId, User currentUser) {
-        // 팔로잉하고 있는 해당 유저 존재하는지 확인
-        var following = getUserEntity(userId);
-        var followEntities = followRepository.findByFollowing(following);
-        return followEntities.stream().map(follow -> getUserWithFollowingStatus(currentUser, follow.getFollower())).toList();
-    }
-
-    /**
-     * userId가 팔로워 (userId가 팔로잉하고 있는 리스트)
-     * 내가 팔로우한 사람들 (팔로잉 목록)
-     */
-    @Override
-    public List<UserDto> getFollowingsByUser(Long userId, User currentUser) {
-        var follower = getUserEntity(userId);
-        var followEntities = followRepository.findByFollower(follower);
-        return followEntities.stream().map(follow -> getUserWithFollowingStatus(currentUser, follow.getFollowing())).toList();
     }
 
     @Override


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #49 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
-  GET /{userId}/followers, GET /{userId}/followings 엔드포인트에 커서 기반 페이징 적용
- 기존에 전체 목록을 한 번에 반환하던 방식에서 SliceResponse 기반으로 변경 
- 커서 기준: Follow.id 내림차순
- 팔로워 조회: Follow.following = targetUser → follow.getFollower() 반환
- 팔로잉 조회: Follow.follower = targetUser → follow.getFollowing() 반환 


 ## 페이징 응답 형식

  ```json
  {
    "content": [...],
    "hasNext": true,
    "nextCursorId": 42,
    "size": 10
  }

```

```
  ┌───────────────────┬───────────────────────────────┬────────────────────────────────┐
  │                   │      getFollowersByUser       │      getFollowingsByUser       │
  ├───────────────────┼───────────────────────────────┼────────────────────────────────┤
  │ 찾는 것           │ 나를 팔로우한 사람들          │ 내가 팔로우한 사람들           │
  ├───────────────────┼───────────────────────────────┼────────────────────────────────┤
  │ Follow 조건       │ following = targetUser        │ follower = targetUser          │
  ├───────────────────┼───────────────────────────────┼────────────────────────────────┤
  │ 반환 유저         │ follow.getFollower()          │ follow.getFollowing()          │
  ├───────────────────┼───────────────────────────────┼────────────────────────────────┤
  │ Repository 메서드 │ findFollowersByUserWithCursor │ findFollowingsByUserWithCursor │
  └───────────────────┴───────────────────────────────┴────────────────────────────────┘
```

## 💫 타입

- [ ] 기능
- [ ] 버그
- [x] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 