### PR TITLE
[Feat] VinylDocument 엘라스틱 서치 인덱스 매핑

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ docker-compose up -d
 
 ## 인프라 요구사항
 - Swagger UI: `http://localhost:8080/swagger-ui/index.html`
+- Elasticsearch: `http://localhost:9200` — 공식 이미지가 아닌 커스텀 빌드가 필요 (`docker-compose build elasticsearch`), 자세한 내용은 아래 [Elasticsearch 검색](#elasticsearch-검색-진행-중) 참고
 
 ## 아키텍처 개요
 
@@ -100,3 +101,16 @@ Discogs API 콘텐츠는 두 종류로 나뉘며, 종류에 따라 저장/사용
 ### Kakao OAuth2
 
 `application-dev.yml`에 설정. `SocialOAuth2UserService` + `SocialOAuth2User`로 구현. `SecurityConfig`에서 oauth2Login 설정이 주석 처리되어 있어 현재 비활성 상태.
+
+### Elasticsearch 검색 (진행 중)
+
+Vinyl 검색 기능을 위해 Elasticsearch 도입 중. **로컬 개발 환경 구성은 완료, 색인/검색 애플리케이션 코드는 미착수.**
+
+**환경 구성** (`docker-compose.yml`, `docker/elasticsearch/Dockerfile`):
+- ES 8.15.0 기반에 Nori(한국어 형태소 분석기) 플러그인을 설치한 커스텀 이미지를 빌드해서 사용. 공식 이미지엔 Nori가 기본 포함되어 있지 않아 Dockerfile로 `elasticsearch-plugin install analysis-nori`를 빌드 타임에 실행함
+- 로컬 전용 설정: `xpack.security.enabled: false`로 인증 비활성화 (ES 8.x는 기본값이 `true`라 미설정 시 모든 요청이 401). **운영 배포 시 재검토 필요**
+- `discovery.type: single-node`(단일 노드 부팅), `esdata` volume(컨테이너 재생성해도 색인 데이터 유지)
+- Spring 연결: `application.yml`의 `spring.elasticsearch.uris: http://localhost:9200`
+- 별도 네트워크(`es-bridge` 등) 불필요 — 같은 compose 파일 내 서비스는 기본 네트워크로 서비스명 통신 가능. Kibana/Logstash도 아직 미도입 (필요해지면 같은 이유로 커스텀 네트워크 없이 추가 가능)
+
+**남은 작업**: `VinylDocument`(Nori 매핑 포함 인덱스 설계), `VinylSearchRepository`, Vinyl 생성/수정 시 ES 동기화 로직(`VinylServiceImpl`), 검색 API 컨트롤러

--- a/src/main/java/miiiiiin/com/vinyler/application/document/VinylDocument.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/document/VinylDocument.java
@@ -1,0 +1,62 @@
+package miiiiiin.com.vinyler.application.document;
+
+import lombok.*;
+import miiiiiin.com.vinyler.application.entity.vinyl.Vinyl;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+import java.lang.reflect.Type;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(indexName = "vinyls") // 매핑될 ES 인덱스 이름 지정
+@Setting(settingPath = "elasticsearch/vinyl-setting.json")
+public class VinylDocument {
+
+    @Id
+    private Long discogsId;
+
+    /** 검색 대상 텍스트 필드 (NORI 분석기 적용)
+     *  FieldType.Text : 형태소 분석기 태워서 토큰화하는 타입. 부분 검색/유사 검색이
+     *  analyzer = "korean" : 커스텀 analyzer 이름 참조 (vinyl-settings.json)
+     */
+    @Field(type = FieldType.Text, analyzer = "korean")
+    private String title;
+
+    @Field(type = FieldType.Text, analyzer = "korean")
+    private String artistsSort;
+
+
+    /** 정렬/필터용 필드
+     * Keyword : 형태소 분석 덦이 " 값 전체"를 그대로 하나의 토큰으로 저장 (발매일 문자열은 굳이 토큰 쪼개서 검색할 필요 X)
+     */
+    @Field(type = FieldType.Keyword)
+    private String releasedFormatted;
+
+    @Field(type = FieldType.Long)
+    private Long likesCount;
+
+    @Field(type = FieldType.Long)
+    private Long reviewsCount;
+
+    public static VinylDocument from(Vinyl vinyl) {
+        return VinylDocument.builder()
+                .discogsId(vinyl.getDiscogsId())
+                .title(vinyl.getTitle())
+                .artistsSort(vinyl.getArtistsSort())
+                .releasedFormatted(vinyl.getReleasedFormatted())
+                .likesCount(vinyl.getLikesCount())
+                .reviewsCount(vinyl.getReviewsCount())
+                .build();
+    }
+
+
+
+
+
+}

--- a/src/main/java/miiiiiin/com/vinyler/application/document/VinylDocument.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/document/VinylDocument.java
@@ -15,7 +15,7 @@ import java.lang.reflect.Type;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(indexName = "vinyls") // 매핑될 ES 인덱스 이름 지정
-@Setting(settingPath = "elasticsearch/vinyl-setting.json")
+@Setting(settingPath = "elasticsearch/vinyl-settings.json")
 public class VinylDocument {
 
     @Id

--- a/src/main/java/miiiiiin/com/vinyler/application/dto/enums/VinylSortType.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/dto/enums/VinylSortType.java
@@ -1,0 +1,20 @@
+package miiiiiin.com.vinyler.application.dto.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+
+@Getter
+@RequiredArgsConstructor
+public enum VinylSortType {
+    REVIEWS("reviewsCount"), //리뷰 많은 순
+    LIKES("likesCount"); //찜 많은 순
+
+    // 엘라스틱 서치 문서(VinylDocument)의 실제 정렬 대상 필드명
+    private final String field;
+
+    // 위 정렬 타입을 Sort 객체로 변환 (항상 내림차순 = 많은 순)
+    public Sort toSort() {
+        return  Sort.by(Sort.Direction.DESC, field);
+    }
+}

--- a/src/main/java/miiiiiin/com/vinyler/application/dto/response/VinylSearchResultDto.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/dto/response/VinylSearchResultDto.java
@@ -1,0 +1,46 @@
+package miiiiiin.com.vinyler.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import miiiiiin.com.vinyler.application.document.VinylDocument;
+
+@Getter
+@Builder
+@Schema(description = "Vinyl 검색 결과(엘라스틱 서치)")
+public record VinylSearchResultDto(
+        @JsonProperty("discogs_id")
+        @Schema(description = "Discogs Release ID", example = "1234567")
+        Long discogsId,
+
+        @Schema(description = "음반 제목", example = "Kind of Blue")
+        String title,
+
+        @JsonProperty("artists_sort")
+        @Schema(description = "아티스트 이름", example = "Miles Davis")
+        String artistsSort,
+
+        @JsonProperty("released_formatted")
+        @Schema(description = "출시일 (포맷 문자열)", example = "1959")
+        String releasedFormatted,
+
+        @Schema(description = "찜 수", example = "123")
+        Long likesCount,
+
+        @Schema(description = "리뷰 수", example = "12")
+        Long reviewsCount
+) {
+
+        // 엘라스틱 색인 문서 -> 클라이언트 응답 DTO
+        public static VinylSearchResultDto from(VinylDocument doc) {
+                return VinylSearchResultDto.builder()
+                        .discogsId(doc.getDiscogsId())
+                        .title(doc.getTitle())
+                        .artistsSort(doc.getArtistsSort())
+                        .releasedFormatted(doc.getReleasedFormatted())
+                        .likesCount(doc.getLikesCount())
+                        .reviewsCount(doc.getReviewsCount())
+                        .build();
+        }
+}

--- a/src/main/java/miiiiiin/com/vinyler/application/repository/VinylerElasticSearchRepository.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/repository/VinylerElasticSearchRepository.java
@@ -1,0 +1,20 @@
+package miiiiiin.com.vinyler.application.repository;
+
+import miiiiiin.com.vinyler.application.document.VinylDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface VinylerElasticSearchRepository extends ElasticsearchRepository<VinylDocument, Long> {
+
+    @Query("""
+        {
+            "multi_match" : {
+                "query" : "?0",
+                "fields" : ["title", "artistsSort"]
+            }
+        }
+    """)
+    Page<VinylDocument> searchByKeyword(String keyword, Pageable pageable);
+}

--- a/src/main/java/miiiiiin/com/vinyler/application/service/VinylElasticSearchService.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/VinylElasticSearchService.java
@@ -1,0 +1,9 @@
+package miiiiiin.com.vinyler.application.service;
+
+import miiiiiin.com.vinyler.application.dto.enums.VinylSortType;
+import miiiiiin.com.vinyler.application.dto.response.VinylSearchResultDto;
+import org.springframework.data.domain.Page;
+
+public interface VinylElasticSearchService {
+    Page<VinylSearchResultDto> search(String keyword, VinylSortType sortType, int page, int size);
+}

--- a/src/main/java/miiiiiin/com/vinyler/application/service/VinylElasticSearchServiceImpl.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/VinylElasticSearchServiceImpl.java
@@ -1,0 +1,26 @@
+package miiiiiin.com.vinyler.application.service;
+
+import lombok.RequiredArgsConstructor;
+import miiiiiin.com.vinyler.application.dto.enums.VinylSortType;
+import miiiiiin.com.vinyler.application.dto.response.VinylSearchResultDto;
+import miiiiiin.com.vinyler.application.repository.VinylerElasticSearchRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class VinylElasticSearchServiceImpl implements VinylElasticSearchService {
+
+    private final VinylerElasticSearchRepository vinylSearchRepository;
+    @Override
+    public Page<VinylSearchResultDto> search(String keyword, VinylSortType sortType, int page, int size) {
+        // page/size 정렬 기준을 Pageable로 조립 (정렬 필드는 enum이 알고 있음)
+        Pageable pageable = PageRequest.of(page, size, sortType.toSort());
+
+        // 엘라스틱 서치 검색 실행 -> 색인 문서를 응답 DTO로 반환
+        return vinylSearchRepository.searchByKeyword(keyword, pageable)
+                .map(VinylSearchResultDto::from);
+    }
+}

--- a/src/main/resources/elasticsearch/vinyl-settings.json
+++ b/src/main/resources/elasticsearch/vinyl-settings.json
@@ -1,0 +1,26 @@
+{
+  "analysis": {
+    "tokenizer": {
+      "nori_mixed_tokenizer": {
+        "type": "nori_tokenizer",
+        "decompound_mode": "mixed"
+      }
+    },
+    "filter": {
+      "nori_readingform_filter": {
+        "type": "nori_readingform"
+      }
+    },
+    "analyzer": {
+      "korean": {
+        "type": "custom",
+        "tokenizer": "nori_mixed_tokenizer",
+        "filter": [
+          "nori_readingform_filter",
+          "lowercase"
+        ]
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
# 🌟 풀 리퀘스트
Vinyler 자체 소셜 지표 기반(리뷰 많은 순 / 찜 많은 순) 음반 검색을 위한 기능을 위해 Elasticsearch 검색의 기반 계층을 구성
"검색을 실행하는 쪽"까지 완료


## 🌐 이슈 번호
- #53 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- Nori 형태소 분석기 설정 (json)
- 엘라스틱 서치 색인 문서 클래스 추가 (@Document(indexName = "vinyls") 분석기 설정)
- 엘라스틱 서치 전용 레포지토리/서비스 계층 구성

## 💫 타입

- [x] 기능
- [ ] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
