### PR TITLE
[Feature] Vinyl 데이터 색인 및 "이벤트 기반 실시간 동기화 처리(PostgreSQL -> ElasticSearch)

### DIFF
--- a/src/main/java/miiiiiin/com/vinyler/application/document/VinylDocument.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/document/VinylDocument.java
@@ -54,9 +54,4 @@ public class VinylDocument {
                 .reviewsCount(vinyl.getReviewsCount())
                 .build();
     }
-
-
-
-
-
 }

--- a/src/main/java/miiiiiin/com/vinyler/application/event/VinylIndexSyncEvent.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/event/VinylIndexSyncEvent.java
@@ -1,0 +1,9 @@
+package miiiiiin.com.vinyler.application.event;
+
+/**
+ * Vinyl의 색인 대상 데이터(제목/아티스트/찜수/리뷰수)가 변경되었음을 알리는 이벤트
+ * discogsId만 담고, 실제 최신 데이터는 리스너가 DB에서 다시 조회한다
+ */
+public record VinylIndexSyncEvent(Long discogsId) {
+
+}

--- a/src/main/java/miiiiiin/com/vinyler/application/event/VinylIndexSyncListener.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/event/VinylIndexSyncListener.java
@@ -1,0 +1,39 @@
+package miiiiiin.com.vinyler.application.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import miiiiiin.com.vinyler.application.document.VinylDocument;
+import miiiiiin.com.vinyler.application.repository.VinylRepository;
+import miiiiiin.com.vinyler.application.repository.VinylerElasticSearchRepository;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 발행된 이벤트를 실제로 받아서
+ * "DB에서 최신 Vinyl 조회 -> VinylDocument로 변환 -> 엘라스틱 서치에 저장"을 수행
+ * db와 엘라스틱 서치 두 저장소 연결되는 부분
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VinylIndexSyncListener {
+
+    private final VinylRepository vinylRepository;
+    private final VinylerElasticSearchRepository vinylSearchRepository;
+
+    @Async("esSyncExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(VinylIndexSyncEvent event) {
+        vinylRepository.findByDiscogsId(event.discogsId())
+                .ifPresentOrElse(
+                        vinyl -> {
+                            vinylSearchRepository.save(VinylDocument.from(vinyl));
+                            log.info("[엘라스틱 서치 동기화] discogsId={} 색인 완료", event.discogsId());
+                        },
+                        () -> log.warn("[엘라스틱 서치 동기화] discogsId={} Vinyl 객체 미존재, 색인 건너뛰기", event.discogsId())
+                );
+
+    }
+}

--- a/src/main/java/miiiiiin/com/vinyler/application/repository/VinylerElasticSearchRepository.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/repository/VinylerElasticSearchRepository.java
@@ -4,7 +4,7 @@ import miiiiiin.com.vinyler.application.document.VinylDocument;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.elasticsearch.annotations.Query;
 
 public interface VinylerElasticSearchRepository extends ElasticsearchRepository<VinylDocument, Long> {
 

--- a/src/main/java/miiiiiin/com/vinyler/application/service/ReviewServiceImpl.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/ReviewServiceImpl.java
@@ -7,6 +7,7 @@ import miiiiiin.com.vinyler.application.dto.response.ReviewResponseDto;
 import miiiiiin.com.vinyler.application.dto.response.SliceResponse;
 import miiiiiin.com.vinyler.application.entity.Review;
 import miiiiiin.com.vinyler.application.entity.vinyl.Vinyl;
+import miiiiiin.com.vinyler.application.event.VinylIndexSyncEvent;
 import miiiiiin.com.vinyler.application.repository.ReviewRepository;
 import miiiiiin.com.vinyler.application.repository.VinylRepository;
 import miiiiiin.com.vinyler.exception.review.ReviewAlreadyExistException;
@@ -14,6 +15,7 @@ import miiiiiin.com.vinyler.exception.review.ReviewNotFoundException;
 import miiiiiin.com.vinyler.exception.user.UserNotAllowedException;
 import miiiiiin.com.vinyler.exception.vinyl.VinylNotFoundException;
 import miiiiiin.com.vinyler.user.entity.User;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
@@ -28,6 +30,7 @@ public class ReviewServiceImpl implements ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final VinylRepository vinylRepository;
+    private final ApplicationEventPublisher eventPublisher;
 //    private final UserVinylStatusRepository userVinylStatusRepository;
 
     @Override
@@ -48,6 +51,7 @@ public class ReviewServiceImpl implements ReviewService {
 
         vinylEntity.setReviewsCount(vinylEntity.getReviewsCount() + 1);
         vinylRepository.save(vinylEntity);
+        eventPublisher.publishEvent(new VinylIndexSyncEvent(vinylEntity.getDiscogsId()));
 
         return ReviewResponseDto.from(review);
     }
@@ -120,6 +124,7 @@ public class ReviewServiceImpl implements ReviewService {
         var vinylEntity = reviewEntity.getVinyl();
         vinylEntity.setReviewsCount(Math.max(0, vinylEntity.getReviewsCount() - 1));
         vinylRepository.save(vinylEntity);
+        eventPublisher.publishEvent(new VinylIndexSyncEvent(vinylEntity.getDiscogsId()));
     }
 
     private Review getReviewEntity(Long reviewId) {

--- a/src/main/java/miiiiiin/com/vinyler/application/service/VinylServiceImpl.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/VinylServiceImpl.java
@@ -7,11 +7,13 @@ import miiiiiin.com.vinyler.application.dto.request.LikeRequestDto;
 import miiiiiin.com.vinyler.application.entity.Like;
 import miiiiiin.com.vinyler.application.entity.UserVinylStatus;
 import miiiiiin.com.vinyler.application.entity.vinyl.Vinyl;
+import miiiiiin.com.vinyler.application.event.VinylIndexSyncEvent;
 import miiiiiin.com.vinyler.application.repository.LikeRepository;
 import miiiiiin.com.vinyler.application.repository.UserVinylStatusRepository;
 import miiiiiin.com.vinyler.application.repository.VinylRepository;
 import miiiiiin.com.vinyler.global.Constants;
 import miiiiiin.com.vinyler.user.entity.User;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,12 +24,17 @@ public class VinylServiceImpl implements VinylService {
     private final VinylRepository vinylRepository;
     private final LikeRepository likeRepository;
     private final UserVinylStatusRepository userVinylStatusRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
     public Vinyl findOrCreateVinyl(LikeRequestDto requestDto, User user) {
         return vinylRepository.findByDiscogsId(requestDto.discogsId())
-                .orElseGet(() -> vinylRepository.save(buildVinylFromDto(requestDto, user)));
+                .orElseGet(() -> {
+                    Vinyl saved = vinylRepository.save(buildVinylFromDto(requestDto, user));
+                    eventPublisher.publishEvent(new VinylIndexSyncEvent(saved.getDiscogsId()));
+                    return saved;
+                });
     }
 
     @Override
@@ -41,11 +48,15 @@ public class VinylServiceImpl implements VinylService {
         if (likeEntity.isPresent()) {
             likeRepository.delete(likeEntity.get());
             vinylEntity.setLikesCount(Math.max(0, vinylEntity.getLikesCount() - 1));
-            return VinylLikeDto.from(vinylRepository.save(vinylEntity), currentUser, false);
+            var result = VinylLikeDto.from(vinylRepository.save(vinylEntity), currentUser, false);
+            eventPublisher.publishEvent(new VinylIndexSyncEvent(vinylEntity.getDiscogsId()));
+            return result;
         } else {
             likeRepository.save(Like.of(currentUser, vinylEntity));
             vinylEntity.setLikesCount(vinylEntity.getLikesCount() + 1);
-            return VinylLikeDto.from(vinylRepository.save(vinylEntity), currentUser, true);
+            var result = VinylLikeDto.from(vinylRepository.save(vinylEntity), currentUser, true);
+            eventPublisher.publishEvent(new VinylIndexSyncEvent(vinylEntity.getDiscogsId()));
+            return result;
         }
     }
 

--- a/src/main/java/miiiiiin/com/vinyler/config/AsyncConfig.java
+++ b/src/main/java/miiiiiin/com/vinyler/config/AsyncConfig.java
@@ -1,0 +1,28 @@
+package miiiiiin.com.vinyler.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "esSyncExeutor")
+    public Executor esSyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        // 평시 유지 스레드 수
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        // 스레드 다 찼을 때 대기 큐
+        executor.setQueueCapacity(100);
+        // 로그 식별용
+        executor.setThreadNamePrefix("es-sync");
+        executor.initialize();
+        return executor;
+    }
+}


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #54 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- 기존 Vinyl 데이터 색인
- 동기화 전략 (PostgreSQL -> ES) => 이벤트 기반 실시간 동기화
- Vinyl 저장/수정, Like 토글, Review 생성/삭제 시점에 도메인 이벤트(VinylIndexSyncEvent)를 발행
- 커밋 이후 별도 스레드에서 처리되는 구조라, JPA 엔티티 대신 discogsId만 이벤트에 담아 전달 (지연 로딩 오류/stale 데이터 방지 목적)
- @TransactionalEventListener(AFTER_COMMIT) + async 조합으로 API 응답 지연 방지
- 리스너가 해당 discogsId 문서를 다시 읽어 ES에 upsert
- 트랜잭션 커밋 이후 비동기 처리라 API 응답 지연 없음, 대신 ES 반영에는 약간의 지연(eventual consistency) 존재
- 엘라스틱 서치 동기화 전용 스레드풀(`AsyncConfig`) 추가 : 기본 `SimpleAsyncTaskExecutor`의 무제한 스레드 생성 위험을 막기 위해 core 2 / max 5 / queue 100으로 제한

## 💫 타입

- [x] 기능
- [ ] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
