### PR TITLE
[Feat] 엘라스틱 서치 검색 API 생성 및 실시간 인기 검색어 기능 구현

### DIFF
--- a/src/main/java/miiiiiin/com/vinyler/application/controller/VinylSearchController.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/controller/VinylSearchController.java
@@ -38,8 +38,8 @@ public class VinylSearchController {
             @Parameter(description = "정렬 기준", example = "REVIEWS")
             @RequestParam(defaultValue = "REVIEWS")VinylSortType sort,
 
-            @Parameter(description = "페이지 번호(1부터)", example = "1")
-            @RequestParam(defaultValue = "1") int page,
+            @Parameter(description = "페이지 번호(0부터)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
 
             @Parameter(description = "페이지 크기", example = "10")
             @RequestParam(defaultValue = "10") int size) {

--- a/src/main/java/miiiiiin/com/vinyler/application/controller/VinylSearchController.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/controller/VinylSearchController.java
@@ -1,0 +1,51 @@
+package miiiiiin.com.vinyler.application.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import miiiiiin.com.vinyler.application.dto.enums.VinylSortType;
+import miiiiiin.com.vinyler.application.dto.response.VinylSearchResultDto;
+import miiiiiin.com.vinyler.application.service.VinylElasticSearchService;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/vinyls")
+@RequiredArgsConstructor
+@Tag(name = "Vinyl Search", description = "Vinyl 검색(엘라스틱 서치) 엔드포인트")
+public class VinylSearchController {
+
+    private final VinylElasticSearchService vinylSearchService;
+
+    @GetMapping("/search")
+    @Operation(summary = "Vinyl 검색", description = "제목/아티스트를 키워드로 검색합니다. sort로 '리뷰 많은 순(REVIEWS)' 또는 '찜 많은 순(LIKES)'을 선택할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "검색 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터")
+    })
+    public ResponseEntity<Page<VinylSearchResultDto>> search(
+            @Parameter(description = "검색어 (제목/아티스트)", example = "재즈")
+            @RequestParam String keyword,
+
+            @Parameter(description = "정렬 기준", example = "REVIEWS")
+            @RequestParam(defaultValue = "REVIEWS")VinylSortType sort,
+
+            @Parameter(description = "페이지 번호(1부터)", example = "1")
+            @RequestParam(defaultValue = "1") int page,
+
+            @Parameter(description = "페이지 크기", example = "10")
+            @RequestParam(defaultValue = "10") int size) {
+
+        Page<VinylSearchResultDto> result = vinylSearchService.search(keyword, sort, page, size);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+}
+

--- a/src/main/java/miiiiiin/com/vinyler/application/controller/VinylSearchController.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/controller/VinylSearchController.java
@@ -7,7 +7,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import miiiiiin.com.vinyler.application.dto.enums.VinylSortType;
+import miiiiiin.com.vinyler.application.dto.response.PopularKeywordDto;
 import miiiiiin.com.vinyler.application.dto.response.VinylSearchResultDto;
+import miiiiiin.com.vinyler.application.service.PopularKeywordService;
 import miiiiiin.com.vinyler.application.service.VinylElasticSearchService;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -17,6 +19,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/vinyls")
 @RequiredArgsConstructor
@@ -24,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class VinylSearchController {
 
     private final VinylElasticSearchService vinylSearchService;
+    private final PopularKeywordService popularKeywordService;
 
     @GetMapping("/search")
     @Operation(summary = "Vinyl 검색", description = "제목/아티스트를 키워드로 검색합니다. sort로 '리뷰 많은 순(REVIEWS)' 또는 '찜 많은 순(LIKES)'을 선택할 수 있습니다.")
@@ -46,6 +51,15 @@ public class VinylSearchController {
 
         Page<VinylSearchResultDto> result = vinylSearchService.search(keyword, sort, page, size);
         return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
+    @GetMapping("/search/popular-keywords")
+    @Operation(summary = "인기 검색어", description = "가장 많이 검색된 키워드를 상위 N개 반환")
+    public ResponseEntity<List<PopularKeywordDto>> popularKeywords(
+            @Parameter(description = "가져올 개수", example = "10")
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        return ResponseEntity.ok(popularKeywordService.getTopKeywords(limit));
     }
 }
 

--- a/src/main/java/miiiiiin/com/vinyler/application/controller/VinylSearchController.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/controller/VinylSearchController.java
@@ -57,9 +57,12 @@ public class VinylSearchController {
     @Operation(summary = "인기 검색어", description = "가장 많이 검색된 키워드를 상위 N개 반환")
     public ResponseEntity<List<PopularKeywordDto>> popularKeywords(
             @Parameter(description = "가져올 개수", example = "10")
-            @RequestParam(defaultValue = "10") int limit
+            @RequestParam(defaultValue = "10") int limit,
+
+            @Parameter(description = "최근 몇 시간을 합산할지", example = "2")
+            @RequestParam(defaultValue = "2") int hours
     ) {
-        return ResponseEntity.ok(popularKeywordService.getTopKeywords(limit));
+        return ResponseEntity.ok(popularKeywordService.getTopKeywords(limit, hours));
     }
 }
 

--- a/src/main/java/miiiiiin/com/vinyler/application/dto/response/PopularKeywordDto.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/dto/response/PopularKeywordDto.java
@@ -1,0 +1,11 @@
+package miiiiiin.com.vinyler.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "인기 검색어")
+public record PopularKeywordDto(
+        @Schema(description = "순위(1부터)", example = "1") long rank,
+        @Schema(description = "검색어", example = "재즈") String keyword,
+        @Schema(description = "검색 횟수", example = "153") long count
+) {
+}

--- a/src/main/java/miiiiiin/com/vinyler/application/dto/response/VinylSearchResultDto.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/dto/response/VinylSearchResultDto.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import miiiiiin.com.vinyler.application.document.VinylDocument;
 
-@Getter
 @Builder
 @Schema(description = "Vinyl 검색 결과(엘라스틱 서치)")
 public record VinylSearchResultDto(

--- a/src/main/java/miiiiiin/com/vinyler/application/repository/VinylerElasticSearchRepository.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/repository/VinylerElasticSearchRepository.java
@@ -12,7 +12,8 @@ public interface VinylerElasticSearchRepository extends ElasticsearchRepository<
         {
             "multi_match" : {
                 "query" : "?0",
-                "fields" : ["title", "artistsSort"]
+                "fields" : ["title^2", "artistsSort"],
+                "fuzziness" : "AUTO"
             }
         }
     """)

--- a/src/main/java/miiiiiin/com/vinyler/application/service/PopularKeywordService.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/PopularKeywordService.java
@@ -6,6 +6,9 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -20,15 +23,33 @@ public class PopularKeywordService {
      */
     private final RedisTemplate<String, Object> redisTemplate;
 
-    private static final String KEY = "popular:keywords";
+    private static final String KEY_PREFIX = "search:keyword:";
+    // 시간대(시 단위) 버킷 키 포맷: search:keyword:2026070614
+    private static final DateTimeFormatter BUCKET_FMT = DateTimeFormatter.ofPattern("yyyyMMddHH");
+    // 버킷 보관 기간(조회 윈도우보다 넉넉히) — 지나면 Redis가 자동 삭제
+    private static final Duration BUCKET_TTL = Duration.ofHours(3);
 
-    // 검색 1회 발생 시 점수 +1 (원자적으로)
-    public void record(String keyword) {
-        if (keyword==null) return;
-        String normalized = keyword.trim().toLowerCase();
-        if (normalized.isBlank()) return;
-        redisTemplate.opsForZSet().incrementScore(KEY, normalized, 1);
+    private String bucketKey(LocalDateTime time) {
+        return KEY_PREFIX + time.format(BUCKET_FMT);
     }
+
+    private String normalize(String keyword) {
+        if (keyword == null) return null;
+        String n = keyword.trim().toLowerCase();
+        return n.isBlank() ? null : n;
+    }
+
+    /** 검색 1회 발생 시: 현재 시간 버킷에 점수 +1 + 버킷 TTL 갱신 */
+    public void record(String keyword) {
+        String normalized = normalize(keyword);
+        if (normalized == null) return;
+
+        String key = bucketKey(LocalDateTime.now());
+        redisTemplate.opsForZSet().incrementScore(key, normalized, 1);
+        // 윈도우 밖 버킷 자동 만료
+        redisTemplate.expire(key, BUCKET_TTL);
+    }
+
 
     // 상위 limit개를 점수 내림차순으로 조회
     public List<PopularKeywordDto> getTopKeywords(int limit) {

--- a/src/main/java/miiiiiin/com/vinyler/application/service/PopularKeywordService.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/PopularKeywordService.java
@@ -1,0 +1,47 @@
+package miiiiiin.com.vinyler.application.service;
+
+import lombok.RequiredArgsConstructor;
+import miiiiiin.com.vinyler.application.dto.response.PopularKeywordDto;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class PopularKeywordService {
+
+    /**
+     * 기존 RedisTemplate 빈을 그대로 재사용
+     * 키/값 StringRedisSerializer라 ZSET 멤버 문자열이 그대로 저장됨)
+     */
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final String KEY = "popular:keywords";
+
+    // 검색 1회 발생 시 점수 +1 (원자적으로)
+    public void record(String keyword) {
+        if (keyword==null) return;
+        String normalized = keyword.trim().toLowerCase();
+        if (normalized.isBlank()) return;
+        redisTemplate.opsForZSet().incrementScore(KEY, normalized, 1);
+    }
+
+    // 상위 limit개를 점수 내림차순으로 조회
+    public List<PopularKeywordDto> getTopKeywords(int limit) {
+        Set<ZSetOperations.TypedTuple<Object>> tuples = redisTemplate.opsForZSet().reverseRangeWithScores(KEY, 0, limit - 1);
+        List<PopularKeywordDto> result = new ArrayList<>();
+        if (tuples==null) return result;
+
+        long rank = 1;
+        for (ZSetOperations.TypedTuple<Object> tuple : tuples) {
+            String keyword = String.valueOf(tuple.getValue());
+            long count = tuple.getScore() == null ? 0 : tuple.getScore().longValue();
+            result.add(new PopularKeywordDto(rank++, keyword, count));
+        }
+        return result;
+    }
+}

--- a/src/main/java/miiiiiin/com/vinyler/application/service/PopularKeywordService.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/PopularKeywordService.java
@@ -12,6 +12,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -50,19 +51,43 @@ public class PopularKeywordService {
         redisTemplate.expire(key, BUCKET_TTL);
     }
 
+    /**
+     * 최근 windowHours시간 버킷을 ZUNIONSTORE로 합쳐 상위 limit개 반환
+     * windowHours=2 이면 "지금 시간 + 직전 시간" 버킷 합산 = 실시간 랭킹
+     */
+    public List<PopularKeywordDto> getTopKeywords(int limit, int windowHours) {
+        LocalDateTime now = LocalDateTime.now();
 
-    // 상위 limit개를 점수 내림차순으로 조회
-    public List<PopularKeywordDto> getTopKeywords(int limit) {
-        Set<ZSetOperations.TypedTuple<Object>> tuples = redisTemplate.opsForZSet().reverseRangeWithScores(KEY, 0, limit - 1);
-        List<PopularKeywordDto> result = new ArrayList<>();
-        if (tuples==null) return result;
-
-        long rank = 1;
-        for (ZSetOperations.TypedTuple<Object> tuple : tuples) {
-            String keyword = String.valueOf(tuple.getValue());
-            long count = tuple.getScore() == null ? 0 : tuple.getScore().longValue();
-            result.add(new PopularKeywordDto(rank++, keyword, count));
+        // 최근 windowHours개의 버킷 키 수집 (현재시간부터 과거)
+        List<String> keys = new ArrayList<>();
+        for (int i=0; i<windowHours; i++) {
+            keys.add(bucketKey(now.minusHours(i)));
         }
-        return result;
+
+        // 합친 결과 담을 임시 키(호출마다 유니크 -> 동시 요청 간섭 방지)
+        String destKey = KEY_PREFIX + "union:" + UUID.randomUUID();
+        try {
+            // keys[0]을 기준으로 나머지 버킷 union (같은 멤버 점수 합산)하여 destkey에 저장
+            redisTemplate.opsForZSet().unionAndStore(
+                    keys.get(0),
+                    keys.subList(1, keys.size()),
+                    destKey
+            );
+
+            Set<ZSetOperations.TypedTuple<Object>> tuples = redisTemplate.opsForZSet().reverseRangeWithScores(destKey, 0, limit - 1);
+            List<PopularKeywordDto> result = new ArrayList<>();
+            if (tuples==null) return result;
+
+            long rank = 1;
+            for (ZSetOperations.TypedTuple<Object> tuple : tuples) {
+                String keyword = String.valueOf(tuple.getValue());
+                long count = tuple.getScore() == null ? 0 : tuple.getScore().longValue();
+                result.add(new PopularKeywordDto(rank++, keyword, count));
+            }
+            return result;
+        } finally {
+            // 임시 키 정리
+            redisTemplate.delete(destKey);
+        }
     }
 }

--- a/src/main/java/miiiiiin/com/vinyler/application/service/VinylElasticSearchServiceImpl.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/VinylElasticSearchServiceImpl.java
@@ -14,8 +14,12 @@ import org.springframework.stereotype.Service;
 public class VinylElasticSearchServiceImpl implements VinylElasticSearchService {
 
     private final VinylerElasticSearchRepository vinylSearchRepository;
+    private final PopularKeywordService popularKeywordService;
     @Override
     public Page<VinylSearchResultDto> search(String keyword, VinylSortType sortType, int page, int size) {
+        // 검색어 집계 (인기 검색어용)
+        popularKeywordService.record(keyword);
+
         // page/size 정렬 기준을 Pageable로 조립 (정렬 필드는 enum이 알고 있음)
         Pageable pageable = PageRequest.of(page, size, sortType.toSort());
 

--- a/src/main/java/miiiiiin/com/vinyler/config/AsyncConfig.java
+++ b/src/main/java/miiiiiin/com/vinyler/config/AsyncConfig.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 @EnableAsync
 public class AsyncConfig {
 
-    @Bean(name = "esSyncExeutor")
+    @Bean(name = "esSyncExecutor")
     public Executor esSyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         // 평시 유지 스레드 수


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #55 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- 엘라스틱 서치 적용된 검색 API 엔드포인트 추가
- 제목/아티스트 멀티필드 검색 (title 필드에 가중치 2배, fuzziness: AUTO로 오타 허용)
- 정렬 기준(`REVIEWS`/`LIKES`) 및 페이징
- 인기 검색어 상위 N개 조회 (최근 N시간 윈도우) 
   - PopularKeywordService : Redis ZSET 기반 인기 검색어 집계/랭킹
   - 조회 시 최근 windowHours개의 버킷을 `ZUNIONSTORE`로 합산해 실시간에 가까운 랭킹 산출 (합산용 임시 키는 조회 직후 삭제)



## 💫 타입

- [x] 기능
- [ ] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
