### PR TITLE
[Feat] 엘라스틱 서치 Vinyl 검색 자동완성 API 구현

### DIFF
--- a/src/main/java/miiiiiin/com/vinyler/application/controller/VinylSearchController.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/controller/VinylSearchController.java
@@ -64,5 +64,14 @@ public class VinylSearchController {
     ) {
         return ResponseEntity.ok(popularKeywordService.getTopKeywords(limit, hours));
     }
+
+    @GetMapping("/search/autocomplete")
+    @Operation(summary = "검색 자동완성", description = "입력한 접두어로 시작하는 음반 제목/아티스트를 상위 N개 추천한다")
+    public ResponseEntity<List<VinylSearchResultDto>> autocomplete(
+            @Parameter(description = "입력 중인 검색어", example = "재")
+            @RequestParam String prefix
+    ) {
+        return ResponseEntity.ok(vinylSearchService.autocomplete(prefix));
+    }
 }
 

--- a/src/main/java/miiiiiin/com/vinyler/application/document/VinylDocument.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/document/VinylDocument.java
@@ -44,6 +44,10 @@ public class VinylDocument {
     @Field(type = FieldType.Long)
     private Long reviewsCount;
 
+    /** 자동완성 전용 (title + artistsSort 합쳐서 담음) */
+    @Field(type = FieldType.Search_As_You_Type)
+    private String suggest;
+
     public static VinylDocument from(Vinyl vinyl) {
         return VinylDocument.builder()
                 .discogsId(vinyl.getDiscogsId())
@@ -52,6 +56,7 @@ public class VinylDocument {
                 .releasedFormatted(vinyl.getReleasedFormatted())
                 .likesCount(vinyl.getLikesCount())
                 .reviewsCount(vinyl.getReviewsCount())
+                .suggest(vinyl.getTitle() + " " + vinyl.getArtistsSort())
                 .build();
     }
 }

--- a/src/main/java/miiiiiin/com/vinyler/application/repository/VinylerElasticSearchRepository.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/repository/VinylerElasticSearchRepository.java
@@ -10,6 +10,17 @@ public interface VinylerElasticSearchRepository extends ElasticsearchRepository<
 
     @Query("""
         {
+            "multi_match": {
+                "query": "?0",
+                "type": "bool_prefix",
+                "fields": ["suggest", "suggest._2gram", "suggest._3gram"]
+            }
+        }
+    """)
+    Page<VinylDocument> autocomplete(String prefix, Pageable pageable);
+
+    @Query("""
+        {
             "multi_match" : {
                 "query" : "?0",
                 "fields" : ["title^2", "artistsSort"],

--- a/src/main/java/miiiiiin/com/vinyler/application/service/VinylElasticSearchService.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/VinylElasticSearchService.java
@@ -4,6 +4,10 @@ import miiiiiin.com.vinyler.application.dto.enums.VinylSortType;
 import miiiiiin.com.vinyler.application.dto.response.VinylSearchResultDto;
 import org.springframework.data.domain.Page;
 
+import java.util.List;
+
 public interface VinylElasticSearchService {
     Page<VinylSearchResultDto> search(String keyword, VinylSortType sortType, int page, int size);
+
+    List<VinylSearchResultDto> autocomplete(String prefix);
 }

--- a/src/main/java/miiiiiin/com/vinyler/application/service/VinylElasticSearchServiceImpl.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/VinylElasticSearchServiceImpl.java
@@ -9,6 +9,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class VinylElasticSearchServiceImpl implements VinylElasticSearchService {
@@ -26,5 +28,15 @@ public class VinylElasticSearchServiceImpl implements VinylElasticSearchService 
         // 엘라스틱 서치 검색 실행 -> 색인 문서를 응답 DTO로 반환
         return vinylSearchRepository.searchByKeyword(keyword, pageable)
                 .map(VinylSearchResultDto::from);
+    }
+
+    @Override
+    public List<VinylSearchResultDto> autocomplete(String prefix) {
+        if (prefix ==null || prefix.isBlank()) return List.of();
+        // 상위 5개
+        Pageable top = PageRequest.of(0, 5);
+        return vinylSearchRepository.autocomplete(prefix.trim(), top)
+                .map(VinylSearchResultDto::from)
+                .getContent();
     }
 }


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #56 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- vinylDocument 자동완성 관련 필드 타입 추가 (search_as_you_type)
- _2gram/_3gram+ prefix 매칭을 지원하는 `search_as_you_type` 필드 타입 적용
- 자동완성 엔드포인트, 서비스, 조회 메서드 추가 (상위 5개 추천 결과 반환)
- 


## 💫 타입

- [x] 기능
- [ ] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
