### PR TITLE
[TEST] 엘라스틱 서치 기능 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,11 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    // TestContainers
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:elasticsearch'
 }
 
 tasks.named('test') {

--- a/src/test/java/miiiiiin/com/vinyler/application/service/VinylElasticSearchServiceImplTest.java
+++ b/src/test/java/miiiiiin/com/vinyler/application/service/VinylElasticSearchServiceImplTest.java
@@ -1,0 +1,69 @@
+package miiiiiin.com.vinyler.application.service;
+
+import miiiiiin.com.vinyler.application.document.VinylDocument;
+import miiiiiin.com.vinyler.application.dto.enums.VinylSortType;
+import miiiiiin.com.vinyler.application.dto.response.VinylSearchResultDto;
+import miiiiiin.com.vinyler.application.repository.VinylerElasticSearchRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VinylElasticSearchService 단위 테스트")
+public class VinylElasticSearchServiceImplTest {
+    @Mock
+    private VinylerElasticSearchRepository vinylSearchRepository;
+
+    @InjectMocks
+    private VinylElasticSearchServiceImpl service;
+
+    @Test
+    @DisplayName("검색 - 정렬기준(LIKES)이 likesCount DESC로 리포지토리에 전달되고 DTO로 변환된다")
+    void search_정렬적용_및_DTO변환() {
+        // given
+        VinylDocument doc = VinylDocument.builder()
+                .discogsId(1L)
+                .title("재즈 명반")
+                .artistsSort("Miles Davis")
+                .likesCount(10L)
+                .reviewsCount(2L)
+                .build();
+
+        when(vinylSearchRepository.searchByKeyword(eq("재즈"), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(doc)));
+
+        // when
+        Page<VinylSearchResultDto> result = service.search("재즈", VinylSortType.LIKES, 0, 20);
+
+        // then (리포지토리에 넘어간 Pageable의 정렬이 likesCount DESC인지)
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(vinylSearchRepository).searchByKeyword(eq("재즈"), captor.capture());
+        Sort.Order order = captor.getValue().getSort().getOrderFor("likesCount");
+        assertThat(order).isNotNull();
+        assertThat(order.getDirection()).isEqualTo(Sort.Direction.DESC);
+
+        // VinylDocument -> VinylSearchResultDto 변환 확인
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).discogsId()).isEqualTo(1L);
+        assertThat(result.getContent().get(0).title()).isEqualTo("재즈 명반");
+    }
+
+
+
+    }

--- a/src/test/java/miiiiiin/com/vinyler/application/service/VinylElasticSearchServiceImplTest.java
+++ b/src/test/java/miiiiiin/com/vinyler/application/service/VinylElasticSearchServiceImplTest.java
@@ -30,6 +30,9 @@ public class VinylElasticSearchServiceImplTest {
     @Mock
     private VinylerElasticSearchRepository vinylSearchRepository;
 
+    @Mock
+    private PopularKeywordService popularKeywordService;
+
     @InjectMocks
     private VinylElasticSearchServiceImpl service;
 
@@ -52,6 +55,7 @@ public class VinylElasticSearchServiceImplTest {
         Page<VinylSearchResultDto> result = service.search("재즈", VinylSortType.LIKES, 0, 20);
 
         // then (리포지토리에 넘어간 Pageable의 정렬이 likesCount DESC인지)
+        // repo에 어떤 정렬로 요청했는지 (VinylSortType.LIKES -> likesCount DESC로 변환되는지)
         ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
         verify(vinylSearchRepository).searchByKeyword(eq("재즈"), captor.capture());
         Sort.Order order = captor.getValue().getSort().getOrderFor("likesCount");
@@ -66,4 +70,6 @@ public class VinylElasticSearchServiceImplTest {
 
 
 
-    }
+
+
+}

--- a/src/test/java/miiiiiin/com/vinyler/search/PopularKeywordServiceTest.java
+++ b/src/test/java/miiiiiin/com/vinyler/search/PopularKeywordServiceTest.java
@@ -1,0 +1,122 @@
+package miiiiiin.com.vinyler.search;
+
+import miiiiiin.com.vinyler.application.dto.response.PopularKeywordDto;
+import miiiiiin.com.vinyler.application.service.PopularKeywordService;
+import miiiiiin.com.vinyler.config.RedisConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = {RedisConfig.class, PopularKeywordService.class})
+@Testcontainers
+@DisplayName("인기 검색어 통합 테스트 (실제 Redis)")
+public class PopularKeywordServiceTest {
+
+    @Container
+    static final GenericContainer<?> redis =
+            new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+                    .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProps(DynamicPropertyRegistry registry) {
+        registry.add("data.redis.host", redis::getHost);
+        registry.add("data.redis.port", () -> redis.getMappedPort(6379));
+        // 테스트 컨테이너는 무비번
+        registry.add("data.redis.password", () -> "");
+    }
+
+    @Autowired
+    PopularKeywordService service;
+    @Autowired
+    RedisTemplate<String, Object> redisTemplate;
+    static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyyMMddHH");
+    @BeforeEach
+    void clean() {
+        redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+    }
+
+    @Test
+    @DisplayName("기록 : 같은 검색어를 여러 번 치면 점수가 누적된다")
+    void record_누적() {
+        service.record("재즈");
+        service.record("재즈");
+        service.record("록");
+
+        List<PopularKeywordDto> topKeywords = service.getTopKeywords(10, 1);
+
+        // 검색 횟수 높은 대로 결과 나오는지 확인
+        assertThat(topKeywords).extracting(PopularKeywordDto::keyword)
+                .containsExactly("재즈", "록");
+
+        // 재즈 2회 검색 (ZINCRBY가 같은 멤버 점수를 실제로 더한다))
+        assertThat(topKeywords.get(0).count()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("정규화 : 대소문자/공백이 달라도 같은 검색어로 합산된다")
+    void record_정규화() {
+        service.record("Jazz");
+        service.record("JAZZ");
+        service.record("  jazz ");
+
+        List<PopularKeywordDto> topKeywords = service.getTopKeywords(10, 1);
+        assertThat(topKeywords).hasSize(1);
+        // 소문자 jazz와 같은지
+        assertThat(topKeywords.get(0).keyword()).isEqualTo("jazz");
+        // 3개가 하나로 합쳐져서 검색되는지
+        assertThat(topKeywords.get(0).count()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("윈도우 : 최근 2시간 버킷은 합산하고, 그 밖은 제외한다")
+    void getTop_윈도우_합산과_제외() {
+        LocalDateTime now = LocalDateTime.now();
+        String prefix = "search:keyword:";
+        String cur = prefix + now.format(FMT);
+        String prev = prefix + now.minusHours(1).format(FMT);
+        // 윈도우 밖
+        String old  = prefix + now.minusHours(3).format(FMT);
+
+        redisTemplate.opsForZSet().add(prev, "시티팝", 4);
+        redisTemplate.opsForZSet().add(cur, "시티팝", 6);
+        redisTemplate.opsForZSet().add(old, "재즈", 99);
+
+        List<PopularKeywordDto> topKeywords = service.getTopKeywords(10, 2);
+
+        // 3시간 전 버킷은 윈도우 밖이므로 포함하지 않음
+        assertThat(topKeywords).extracting(PopularKeywordDto::keyword)
+                .contains("시티팝")
+                .doesNotContain("재즈");
+
+        // 2시간 동안 같은 멤버의 검색 점수 합산 (ZUNIONSTORE가 최근 2시간을 합산(4+6=10))
+        assertThat(topKeywords.get(0).count()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("TTL : 기록하면 버킷에 만료 시간이 걸린다")
+    void record_TTL() {
+        service.record("록");
+        String cur = "search:keyword:" + LocalDateTime.now().format(FMT);
+
+        Long ttl = redisTemplate.getExpire(cur, TimeUnit.SECONDS);
+
+        // 만료 미설정이면 -1
+        assertThat(ttl).isPositive();
+    }
+}

--- a/src/test/java/miiiiiin/com/vinyler/search/VinylSearchElasticsearchTest.java
+++ b/src/test/java/miiiiiin/com/vinyler/search/VinylSearchElasticsearchTest.java
@@ -1,0 +1,107 @@
+package miiiiiin.com.vinyler.search;
+
+import miiiiiin.com.vinyler.application.document.VinylDocument;
+import miiiiiin.com.vinyler.application.repository.VinylerElasticSearchRepository;
+import miiiiiin.com.vinyler.support.ElasticsearchTestContainerConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.elasticsearch.DataElasticsearchTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataElasticsearchTest
+@Testcontainers
+@Import(ElasticsearchTestContainerConfig.class) // 공용 설정 끌어옴
+@DisplayName("Vinyl 검색 통합 테스트 (실제 elasticsearch + nori)")
+public class VinylSearchElasticsearchTest {
+
+    @Autowired
+    VinylerElasticSearchRepository repo;
+
+    @Autowired
+    ElasticsearchOperations ops;
+
+    @BeforeEach
+    void setUp() {
+        // 매 테스트마다 @Setting/@Field 매핑대로 인덱스를 새로 생성
+        IndexOperations idx = ops.indexOps(VinylDocument.class);
+        if (idx.exists()) idx.delete();
+        idx.createWithMapping();
+    }
+
+    private  void index(VinylDocument doc) {
+        repo.save(doc);
+        // 저장 즉시 검색 가능하게
+        ops.indexOps(VinylDocument.class).refresh();
+    }
+
+    private VinylDocument vinyl(long id, String title, String artist, long likes) {
+        return VinylDocument.builder()
+                .discogsId(id).title(title).artistsSort(artist)
+                .likesCount(likes).reviewsCount(0L)
+                .suggest(title + " " + artist).build();
+    }
+
+    @Test
+    @DisplayName("한국어 검색 : NORI로 '재즈 명반'이 토큰화되어 '명반'으로도 검색된다")
+    void 한국어_형태소_검색() {
+        //  nori 설정 실제로 붙었는지 검증
+        index(vinyl(1L, "재즈 명반", "Miles Davis", 5L));
+
+        // '명반'만 쳐도 잡히면 = 통짜 문자열이 아니라 형태소로 색인됐다는 증거
+        Page<VinylDocument> page = repo.searchByKeyword("명반", PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).extracting(VinylDocument::getTitle).contains("재즈 명반");
+    }
+
+    @Test
+    @DisplayName("오타 허용 : fuzziness로 'Milez'가 'Miles Davis'를 찾는다")
+    void 오타_검색() {
+        index(vinyl(1L, "Kind of Blue", "Miles Davis", 5L));
+
+        Page<VinylDocument> page = repo.searchByKeyword("Milez", PageRequest.of(0, 10));
+        assertThat(page.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("정렬 : 찜 많은 순(likesCount DESC)으로 반환된다")
+    void 찜_많은순_정렬() {
+        index(vinyl(1L, "재즈 A", "V/A", 3L));
+        index(vinyl(2L, "재즈 B", "V/A", 9L));
+        index(vinyl(3L, "재즈 C", "V/A", 6L));
+
+        Page<VinylDocument> page = repo.searchByKeyword("재즈",
+                PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "likesCount")));
+
+        assertThat(page.getContent()).extracting(VinylDocument::getLikesCount)
+                .containsExactly(9L, 6L, 3L);
+    }
+
+    @Test
+    @DisplayName("자동완성 : '재' 접두어로 'search_as_you_type' 매핑이 동작한다")
+    void 자동완성_접두어() {
+        index(vinyl(1L, "재즈 명반", "Miles Davis", 5L));
+
+        Page<VinylDocument> page = repo.autocomplete("재", PageRequest.of(0, 5));
+        assertThat(page.getTotalElements()).isEqualTo(1);
+    }
+
+
+
+
+
+
+
+
+
+
+}

--- a/src/test/java/miiiiiin/com/vinyler/support/ElasticsearchTestContainerConfig.java
+++ b/src/test/java/miiiiiin/com/vinyler/support/ElasticsearchTestContainerConfig.java
@@ -1,0 +1,33 @@
+package miiiiiin.com.vinyler.support;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.DockerImageName;
+
+import java.nio.file.Paths;
+import java.time.Duration;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class ElasticsearchTestContainerConfig {
+
+    // docker/elasticsearch/Dockerfile(Nori 포함)을 테스트 실행 시점에 직접 빌드
+    // 미리 수동으로 이미지를 만들어둘 필요가 없어 로컬/CI 어디서든 동일하게 동작
+    static final ImageFromDockerfile NORI_IMAGE = new ImageFromDockerfile()
+            .withDockerfile(Paths.get("docker/elasticsearch/Dockerfile"));
+
+    // spring.elasticsearch.uris 를 이 컨테이너로 자동 연결
+    @Bean
+    @ServiceConnection
+    ElasticsearchContainer elasticsearchContainer() {
+        return new ElasticsearchContainer(
+                DockerImageName.parse(NORI_IMAGE.get())
+                        .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"))
+                .withEnv("discovery.type", "single-node")
+                .withEnv("xpack.security.enabled", "false")
+                // 엘라스틱 서치 콜드 스타트가 기본 대기시간(60초)보다 오래 걸릴 수 있어 넉넉히 설정
+                .withStartupTimeout(Duration.ofMinutes(3));
+    }
+}


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #100 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- Testcontainers 의존성 추가
- ElasticsearchTestContainerConfig 설정 추가 (docker/elasticsearch/Dockerfile(Nori 포함)을 테스트 실행 시점에 직접 빌드해서 컨테이너로 띄우는 공용 테스트 설정)
- 실제 ElasticSearch 컨테이너 기준 통합 테스트
- 인기검색어 : 실제 Redis 컨테이너(`redis:7-alpine`) 기준 통합 테스트

## 💫 타입

- [ ] 기능
- [ ] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
- [x] 테스트 코드
