### PR TITLE
[Feat] 좋아요/리뷰 도메인 이벤트 발행

### DIFF
--- a/src/main/java/miiiiiin/com/vinyler/application/controller/VinylController.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/controller/VinylController.java
@@ -10,6 +10,8 @@ import miiiiiin.com.vinyler.application.dto.UserVinylStatusDto;
 import miiiiiin.com.vinyler.application.dto.VinylDetailDto;
 import miiiiiin.com.vinyler.application.dto.VinylLikeDto;
 import miiiiiin.com.vinyler.application.dto.request.LikeRequestDto;
+import miiiiiin.com.vinyler.application.dto.response.PopularVinylDto;
+import miiiiiin.com.vinyler.application.service.PopularVinylService;
 import miiiiiin.com.vinyler.application.service.UserVinylStatusService;
 import miiiiiin.com.vinyler.application.service.VinylService;
 import miiiiiin.com.vinyler.security.UserDetailsImpl;
@@ -17,6 +19,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/vinyls")
@@ -26,6 +30,7 @@ public class VinylController {
 
     private final VinylService vinylService;
     private final UserVinylStatusService uservinylStatusService;
+    private final PopularVinylService popularVinylService;
 
     @PostMapping("/likes")
     @Operation(summary = "찜 토글", description = "Vinyl을 찜하거나 찜 취소합니다. 이미 찜한 경우 취소, 아닌 경우 찜 처리됩니다.")
@@ -65,5 +70,12 @@ public class VinylController {
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
         var response = vinylService.getVinylDetail(discogsId, userDetails.getUser());
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping("/popular")
+    @Operation(summary = "인기 음반 랭킹", description = "좋아요 많은 순 상위 N개 음반을 반환합니다.")
+    public ResponseEntity<List<PopularVinylDto>> popular(
+            @RequestParam(defaultValue = "10") int limit) {
+        return ResponseEntity.ok(popularVinylService.getTop(limit));
     }
 }

--- a/src/main/java/miiiiiin/com/vinyler/application/dto/response/PopularVinylDto.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/dto/response/PopularVinylDto.java
@@ -1,0 +1,13 @@
+package miiiiiin.com.vinyler.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PopularVinylDto(
+        @Schema(description = "인기 음반 순위")
+        long rank,
+        @Schema(description = "음반 id")
+        Long discogsId,
+        @Schema(description = "점수")
+        long score
+) {
+}

--- a/src/main/java/miiiiiin/com/vinyler/application/event/DebugEventListener.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/event/DebugEventListener.java
@@ -1,0 +1,19 @@
+package miiiiiin.com.vinyler.application.event;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class DebugEventListener {
+
+    @EventListener
+    public void onLiked(VinylLikedEvent e) {
+        log.info("[EVENT] 좋아요 eventId={} discogsId={} delta={}", e.eventId(), e.discogsId(), e.delta());
+    }
+    @EventListener
+    public void onReviewChanged(ReviewChangedEvent e) {
+        log.info("[EVENT] 리뷰 eventId={} discogsId={} delta={}", e.eventId(), e.discogsId(), e.delta());
+    }
+}

--- a/src/main/java/miiiiiin/com/vinyler/application/event/ReviewChangedEvent.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/event/ReviewChangedEvent.java
@@ -1,0 +1,5 @@
+package miiiiiin.com.vinyler.application.event;
+
+/** 리뷰 작성/삭제 이벤트. delta: +2(작성) / -2(삭제) */
+public record ReviewChangedEvent(String eventId, Long discogsId, int delta) {
+}

--- a/src/main/java/miiiiiin/com/vinyler/application/event/VinylLikedEvent.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/event/VinylLikedEvent.java
@@ -1,0 +1,8 @@
+package miiiiiin.com.vinyler.application.event;
+
+/** 좋아요 발생/취소 이벤트. delta: +1(좋아요) / -1(취소) */
+public record VinylLikedEvent(
+        String eventId,
+        Long discogsId,
+        int delta) {
+}

--- a/src/main/java/miiiiiin/com/vinyler/application/service/PopularVinylService.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/PopularVinylService.java
@@ -1,0 +1,40 @@
+package miiiiiin.com.vinyler.application.service;
+
+import lombok.RequiredArgsConstructor;
+import miiiiiin.com.vinyler.application.dto.response.PopularVinylDto;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class PopularVinylService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String KEY = "vinyl:popularity";
+
+    // 쓰기: 좋아요 발생 시 점수 가감 (+1 좋아요 / -1 취소)
+    public void addScore(Long discogsId, double delta) {
+        redisTemplate.opsForZSet().incrementScore(KEY, String.valueOf(discogsId), delta);
+    }
+
+    public List<PopularVinylDto> getTop(int limit) {
+        Set<ZSetOperations.TypedTuple<Object>> tuples = redisTemplate.opsForZSet().reverseRangeWithScores(KEY, 0, limit - 1);
+
+        List<PopularVinylDto> result = new ArrayList<>();
+        if (tuples == null) return result;
+
+        long rank = 1;
+        for (ZSetOperations.TypedTuple<Object> t : tuples) {
+            Long discogsId = Long.valueOf(String.valueOf(t.getValue()));
+            long score = t.getScore() == null ? 0 : t.getScore().longValue();
+            result.add(new PopularVinylDto(rank++, discogsId, score));
+        }
+
+        return  result;
+    }
+}

--- a/src/main/java/miiiiiin/com/vinyler/application/service/ReviewServiceImpl.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/ReviewServiceImpl.java
@@ -7,6 +7,7 @@ import miiiiiin.com.vinyler.application.dto.response.ReviewResponseDto;
 import miiiiiin.com.vinyler.application.dto.response.SliceResponse;
 import miiiiiin.com.vinyler.application.entity.Review;
 import miiiiiin.com.vinyler.application.entity.vinyl.Vinyl;
+import miiiiiin.com.vinyler.application.event.ReviewChangedEvent;
 import miiiiiin.com.vinyler.application.event.VinylIndexSyncEvent;
 import miiiiiin.com.vinyler.application.repository.ReviewRepository;
 import miiiiiin.com.vinyler.application.repository.VinylRepository;
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -52,6 +54,8 @@ public class ReviewServiceImpl implements ReviewService {
         vinylEntity.setReviewsCount(vinylEntity.getReviewsCount() + 1);
         vinylRepository.save(vinylEntity);
         eventPublisher.publishEvent(new VinylIndexSyncEvent(vinylEntity.getDiscogsId()));
+        // 리뷰 이벤트 발행 (인기 LP)
+        eventPublisher.publishEvent(new ReviewChangedEvent(UUID.randomUUID().toString(), vinylEntity.getDiscogsId(), +2));
 
         return ReviewResponseDto.from(review);
     }
@@ -125,6 +129,8 @@ public class ReviewServiceImpl implements ReviewService {
         vinylEntity.setReviewsCount(Math.max(0, vinylEntity.getReviewsCount() - 1));
         vinylRepository.save(vinylEntity);
         eventPublisher.publishEvent(new VinylIndexSyncEvent(vinylEntity.getDiscogsId()));
+        // 리뷰 삭제 시 인기 LP 점수 차감
+        eventPublisher.publishEvent(new ReviewChangedEvent(UUID.randomUUID().toString(), vinylEntity.getDiscogsId(), -2));
     }
 
     private Review getReviewEntity(Long reviewId) {

--- a/src/main/java/miiiiiin/com/vinyler/application/service/VinylServiceImpl.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/VinylServiceImpl.java
@@ -8,6 +8,7 @@ import miiiiiin.com.vinyler.application.entity.Like;
 import miiiiiin.com.vinyler.application.entity.UserVinylStatus;
 import miiiiiin.com.vinyler.application.entity.vinyl.Vinyl;
 import miiiiiin.com.vinyler.application.event.VinylIndexSyncEvent;
+import miiiiiin.com.vinyler.application.event.VinylLikedEvent;
 import miiiiiin.com.vinyler.application.repository.LikeRepository;
 import miiiiiin.com.vinyler.application.repository.UserVinylStatusRepository;
 import miiiiiin.com.vinyler.application.repository.VinylRepository;
@@ -17,6 +18,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 public class VinylServiceImpl implements VinylService {
@@ -25,6 +28,7 @@ public class VinylServiceImpl implements VinylService {
     private final LikeRepository likeRepository;
     private final UserVinylStatusRepository userVinylStatusRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final PopularVinylService popularVinylService;
 
     @Override
     @Transactional
@@ -50,12 +54,16 @@ public class VinylServiceImpl implements VinylService {
             vinylEntity.setLikesCount(Math.max(0, vinylEntity.getLikesCount() - 1));
             var result = VinylLikeDto.from(vinylRepository.save(vinylEntity), currentUser, false);
             eventPublisher.publishEvent(new VinylIndexSyncEvent(vinylEntity.getDiscogsId()));
+            // 취소 : -1
+            eventPublisher.publishEvent(new VinylLikedEvent(UUID.randomUUID().toString(), vinylEntity.getDiscogsId(), -1));
             return result;
         } else {
             likeRepository.save(Like.of(currentUser, vinylEntity));
             vinylEntity.setLikesCount(vinylEntity.getLikesCount() + 1);
             var result = VinylLikeDto.from(vinylRepository.save(vinylEntity), currentUser, true);
             eventPublisher.publishEvent(new VinylIndexSyncEvent(vinylEntity.getDiscogsId()));
+            // 좋아요 : +1
+            eventPublisher.publishEvent(new VinylLikedEvent(UUID.randomUUID().toString(), vinylEntity.getDiscogsId(), +1));
             return result;
         }
     }


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #57 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- 리뷰/좋아요 도메인 이벤트 정의/발행
1. 시작 전 정책 확정
  - [x] 점수 가중치 확정 : 좋아요 +1 / 취소 −1 / 리뷰 +2 / 리뷰삭제 −2
  - [x] 랭킹 범위 : 전체 누적 단일 ZSET vinyl:popularity (시간 윈도우는 스트레치)
  - [x] 이벤트에 delta 필드 포함 (취소, 삭제 감소 반영)

2. 도메인 이벤트 정의/발행
  - [x] VinylLikedEvent(eventId, discogsId, delta) 정의 (record)
  - [x] ReviewChangedEvent(eventId, discogsId, delta) 정의
  - [x] toggleLike()에서 ApplicationEventPublisher로 발행 (찜/취소 delta 분기)
  - [x] createReview() / deleteReview()에서 발행

## 💫 타입

- [x] 기능
- [ ] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
