### PR TITLE
[Feat] 이벤트 컨슈머 멱등성 처리 (SET NX 기반 중복 소비 방지)

### DIFF
--- a/src/main/java/miiiiiin/com/vinyler/application/event/VinylEventStreamConsumer.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/event/VinylEventStreamConsumer.java
@@ -9,6 +9,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.stream.StreamListener;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
 import java.util.Map;
 
 @Slf4j
@@ -19,15 +20,32 @@ public class VinylEventStreamConsumer implements StreamListener<String, MapRecor
     private final PopularVinylService popularVinylService;
     private final StringRedisTemplate stringRedisTemplate;
 
+    private static final Duration DEDUP_TTL = Duration.ofDays(1);
+
     // 스트림에 새 메시지가 오면 1건씩 여기로 들어옴
     @Override
     public void onMessage(MapRecord<String, String, String> message) {
         Map<String, String> body = message.getValue();
+        String eventId = body.get("eventId");
         Long discogsId = Long.valueOf(body.get("discogsId"));
         int delta = Integer.parseInt(body.get("delta"));
 
-        // 실제 집계: ZINCRBY vinyl:popularity {delta} {discogsId}
-        popularVinylService.addScore(discogsId, delta);
+        // 멱등성 : processed:{eventId} 도장을 원자적으로 찍음 (SET NX)
+        String dedupKey = "processed:" + eventId;
+        // 새로 찍히면 true(=내가 처음) / 이미 있으면 false(=누가 이미 처리함)
+        Boolean first = stringRedisTemplate.opsForValue()
+                .setIfAbsent(dedupKey, "1", DEDUP_TTL);
+
+        if (Boolean.TRUE.equals(first)) {
+            // 처음 보는 이벤트면 => 실제 집계
+            // 실제 집계: ZINCRBY vinyl:popularity {delta} {discogsId}
+            popularVinylService.addScore(discogsId, delta);
+            log.info("[EVENT STREAM] processed id={} discogsId={} delta={}",
+                    message.getId(), discogsId, delta);
+        } else {
+            // 이미 처리한 이벤트 => 집계 SKIP (중복)
+            log.info("[EVENT STREAM] skip duplicate eventId={}", eventId);
+        }
 
         // 처리 완료 -> ACK (pending 목록에서 제거)
         stringRedisTemplate.opsForStream().acknowledge(
@@ -35,9 +53,6 @@ public class VinylEventStreamConsumer implements StreamListener<String, MapRecor
                 VinylStreamConsumerConfig.GROUP,
                 message.getId()
         );
-
-        log.info("[EVENT STREAM] processed id={} discogsId={} delta={}",
-                message.getId(), discogsId, delta);
     }
 }
 


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #59 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- 중복 소비 방지 기본 처리
- `VinylEventStreamConsumer`에 `processed:{eventId}` 키를 `SET NX`(`setIfAbsent`)로 원자적으로 선점하는 dedup 체크 추가
-  이미 처리된 이벤트(재배달 등으로 `SET NX` 실패)는 집계 스킵하고 로그만 남김
- dedup 키 TTL은 `DEDUP_TTL = 1일`로 설정, 처리 여부와 무관하게 `XACK`은 항상 수행

  - [x] 처리 전 SET NX processed:{eventId} 체크
  - [x] 이미 처리된 이벤트면 skip 후 XACK만
  - [x] 중복 소비해도 점수 1회만 반영되는지 확인


## 💫 타입

- [x] 기능
- [ ] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
