### PR TITLE
[Feat] 인기 음반 랭킹 조회 API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,3 +114,30 @@ Vinyl 검색 기능을 위해 Elasticsearch 도입 중. **로컬 개발 환경 �
 - 별도 네트워크(`es-bridge` 등) 불필요 — 같은 compose 파일 내 서비스는 기본 네트워크로 서비스명 통신 가능. Kibana/Logstash도 아직 미도입 (필요해지면 같은 이유로 커스텀 네트워크 없이 추가 가능)
 
 **남은 작업**: `VinylDocument`(Nori 매핑 포함 인덱스 설계), `VinylSearchRepository`, Vinyl 생성/수정 시 ES 동기화 로직(`VinylServiceImpl`), 검색 API 컨트롤러
+
+### 인기 LP 랭킹 (이벤트 기반 집계)
+
+**파이프라인**
+
+```
+좋아요/리뷰 → ApplicationEvent → Producer(AFTER_COMMIT, XADD)
+→ Redis Stream → Consumer(Consumer Group, XREADGROUP)
+→ 멱등성(SETNX) → ZINCRBY → Sorted Set → GET /popular(ZREVRANGE + DB 제목 조합)
+```
+
+**설계 선택과 이유**
+
+| 선택 | 왜 |
+|---|---|
+| ApplicationEvent | 도메인 로직을 집계/인프라에서 분리 |
+| @TransactionalEventListener(AFTER_COMMIT) | 롤백된 좋아요가 랭킹에 반영되는 것 방지 |
+| Redis Stream | 컨슈머가 죽어도 이벤트 유실 X, 재처리 가능 |
+| Consumer Group + 수동 ACK | "어디까지 읽었나" 기억 + 실패 시 pending 재처리 |
+| SETNX(processed:{eventId}) | at-least-once 배달의 중복을 멱등하게 방어 |
+| Sorted Set | 집계 때 정렬 선불 → 조회 O(logN+N) |
+
+**한계 (트레이드오프)**
+- exactly-once 아님: 커밋~XADD, 도장~집계 사이 좁은 유실/중복 창 존재 → 완전 보장은 Outbox 필요 (현재는 그 직전 단계)
+
+**API**
+- `GET /api/v1/vinyls/popular?limit=10` — 인기 음반 상위 N (rank, discogsId, score, title, artistsSort)

--- a/src/main/java/miiiiiin/com/vinyler/application/controller/VinylController.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/controller/VinylController.java
@@ -73,8 +73,9 @@ public class VinylController {
     }
 
     @GetMapping("/popular")
-    @Operation(summary = "인기 음반 랭킹", description = "좋아요 많은 순 상위 N개 음반을 반환합니다.")
+    @Operation(summary = "인기 음반 랭킹", description = "찜/리뷰 점수 기준 상위 N개 음반을 반환합니다.")
     public ResponseEntity<List<PopularVinylDto>> popular(
+            @Parameter(description = "가져올 개수", example = "10")
             @RequestParam(defaultValue = "10") int limit) {
         return ResponseEntity.ok(popularVinylService.getTop(limit));
     }

--- a/src/main/java/miiiiiin/com/vinyler/application/dto/response/PopularVinylDto.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/dto/response/PopularVinylDto.java
@@ -8,6 +8,12 @@ public record PopularVinylDto(
         @Schema(description = "음반 id")
         Long discogsId,
         @Schema(description = "점수")
-        long score
+        long score,
+
+        @Schema(description = "제목")
+        String title,
+
+        @Schema(description = "아티스트")
+        String artistsSort
 ) {
 }

--- a/src/main/java/miiiiiin/com/vinyler/application/repository/VinylRepository.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/repository/VinylRepository.java
@@ -12,4 +12,7 @@ import java.util.Optional;
 public interface VinylRepository extends JpaRepository<Vinyl, Long> {
     List<Vinyl> findByUser(User user);
     Optional<Vinyl> findByDiscogsId(Long discogsId);
+
+    /** 일괄 조회 */
+    List<Vinyl> findByDiscogsIdIn(List<Long> discogsIds);
 }

--- a/src/main/java/miiiiiin/com/vinyler/application/service/PopularVinylService.java
+++ b/src/main/java/miiiiiin/com/vinyler/application/service/PopularVinylService.java
@@ -2,19 +2,24 @@ package miiiiiin.com.vinyler.application.service;
 
 import lombok.RequiredArgsConstructor;
 import miiiiiin.com.vinyler.application.dto.response.PopularVinylDto;
+import miiiiiin.com.vinyler.application.entity.vinyl.Vinyl;
+import miiiiiin.com.vinyler.application.repository.VinylRepository;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class PopularVinylService {
 
     private final RedisTemplate<String, Object> redisTemplate;
+    private final VinylRepository vinylRepository;
     private static final String KEY = "vinyl:popularity";
 
     // ZINCRBY 쓰기: 좋아요 발생 시 점수 가감 (+1 좋아요 / -1 취소)
@@ -23,16 +28,29 @@ public class PopularVinylService {
     }
 
     public List<PopularVinylDto> getTop(int limit) {
-        Set<ZSetOperations.TypedTuple<Object>> tuples = redisTemplate.opsForZSet().reverseRangeWithScores(KEY, 0, limit - 1);
+        // Redis에서 상위 id + 점수 (이미 점수 내림차순 정렬됨)
+        Set<ZSetOperations.TypedTuple<Object>> tuples = redisTemplate.opsForZSet()
+                .reverseRangeWithScores(KEY, 0, limit - 1);
+        if (tuples == null || tuples.isEmpty()) return List.of();
 
+        // id만 모아 DB 한 번에 조회 -> discogsId로 빠르게 찾도록 Map 구성
+        List<Long> ids = new ArrayList<>();
+        for (var t : tuples) ids.add(Long.valueOf(String.valueOf(t.getValue())));
+
+        Map<Long, Vinyl> vinylMap = vinylRepository.findByDiscogsIdIn(ids).stream()
+                .collect(Collectors.toMap(Vinyl::getDiscogsId, v -> v));
+
+        // 순위 순서는 "Redis tuples" 기준으로 돌면서 제목 채움
         List<PopularVinylDto> result = new ArrayList<>();
-        if (tuples == null) return result;
 
         long rank = 1;
         for (ZSetOperations.TypedTuple<Object> t : tuples) {
             Long discogsId = Long.valueOf(String.valueOf(t.getValue()));
             long score = t.getScore() == null ? 0 : t.getScore().longValue();
-            result.add(new PopularVinylDto(rank++, discogsId, score));
+            Vinyl vinyl = vinylMap.get(discogsId);
+            result.add(new PopularVinylDto(rank++, discogsId, score,
+                    vinyl != null ? vinyl.getTitle() : null,
+                    vinyl != null ? vinyl.getArtistsSort() : null));
         }
 
         return  result;

--- a/src/test/java/miiiiiin/com/vinyler/application/event/VinylEventStreamConsumerTest.java
+++ b/src/test/java/miiiiiin/com/vinyler/application/event/VinylEventStreamConsumerTest.java
@@ -1,0 +1,67 @@
+package miiiiiin.com.vinyler.application.event;
+
+import miiiiiin.com.vinyler.application.service.PopularVinylService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamRecords;
+import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class VinylEventStreamConsumerTest {
+
+    @Mock
+    PopularVinylService popularVinylService;
+    @Mock
+    StringRedisTemplate stringRedisTemplate;
+    @Mock
+    ValueOperations<String, String> valueOps;
+    @Mock
+    StreamOperations<String, Object, Object> streamOps;
+    @InjectMocks
+    VinylEventStreamConsumer consumer;
+
+    private MapRecord<String, String, String> record(String eventId) {
+        Map<String, String> body = Map.of(
+                "eventId", eventId, "type", "LIKE", "discogsId", "12345", "delta", "1");
+        return StreamRecords.mapBacked(body)
+                .withStreamKey("stream:vinyl-events")
+                .withId(RecordId.of("1-0"));
+    }
+
+
+    @Test
+    @DisplayName("같은 eventId 이벤트가 두 번 와도 집계는 한 번만")
+    void duplicateEvent_aggregatesOnce() {
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+        given(stringRedisTemplate.opsForStream()).willReturn(streamOps);
+        // 처음 = true(처음 봄), 두 번째 = false(중복)
+        given(valueOps.setIfAbsent(anyString(), anyString(), any(Duration.class)))
+                .willReturn(true, false);
+
+        var msg = record("evt-1");
+        consumer.onMessage(msg);   // 1회차
+        consumer.onMessage(msg);   // 2회차(중복)
+
+        //  addScore는 1번, acknowledge는 2번. 즉 "중복은 skip하되 pending엔 안 남긴다"
+        verify(popularVinylService, times(1)).addScore(12345L, 1.0); // 집계는 딱 1번
+        verify(streamOps, times(2)).acknowledge(anyString(), anyString(), (String) any()); // ACK는 둘 다
+    }
+}

--- a/src/test/java/miiiiiin/com/vinyler/application/service/PopularVinylServiceTest.java
+++ b/src/test/java/miiiiiin/com/vinyler/application/service/PopularVinylServiceTest.java
@@ -1,0 +1,60 @@
+package miiiiiin.com.vinyler.application.service;
+
+import miiiiiin.com.vinyler.application.dto.response.PopularVinylDto;
+import miiiiiin.com.vinyler.application.entity.vinyl.Vinyl;
+import miiiiiin.com.vinyler.application.repository.VinylRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.DefaultTypedTuple;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class PopularVinylServiceTest {
+    @Mock
+    RedisTemplate<String, Object> redisTemplate;
+    @Mock
+    ZSetOperations<String, Object> zSetOps;
+    @Mock
+    VinylRepository vinylRepository;
+    @InjectMocks
+    PopularVinylService popularVinylService;
+
+    @Test
+    @DisplayName("랭킹 순서는 Redis 기준, 제목은 DB에서 채운다")
+    void getTop_orderFromRedis_titleFromDb() {
+        given(redisTemplate.opsForZSet()).willReturn(zSetOps);
+
+        // Redis 순위: 100(2점) > 200(1점)  ※ 순서 유지되는 LinkedHashSet
+        Set<ZSetOperations.TypedTuple<Object>> tuples = new LinkedHashSet<>();
+        tuples.add(new DefaultTypedTuple<>("100", 2.0));
+        tuples.add(new DefaultTypedTuple<>("200", 1.0));
+        given(zSetOps.reverseRangeWithScores("vinyl:popularity", 0, 9)).willReturn(tuples);
+
+        // DB는 일부러 반대 순서로 반환 (IN 결과 순서 보장 X 상황 재현)
+        given(vinylRepository.findByDiscogsIdIn(anyList())).willReturn(List.of(
+                Vinyl.builder().discogsId(200L).title("B").artistsSort("artB").build(),
+                Vinyl.builder().discogsId(100L).title("A").artistsSort("artA").build()));
+
+        var result = popularVinylService.getTop(10);
+
+        // 순서는 Redis 기준(100 → 200)
+        assertThat(result).extracting(PopularVinylDto::discogsId).containsExactly(100L, 200L);
+        // 제목은 id에 맞게 정확히 매칭
+        assertThat(result.get(0).title()).isEqualTo("A");
+        assertThat(result.get(0).rank()).isEqualTo(1L);
+    }
+}


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #60 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- `PopularVinylDto`에 `title`, `artistsSort` 필드 추가 — 기존엔 `discogsId`/`score`만 내려줘서 클라이언트가 음반 정보를 알 수 없었음
- 테스트 추가


- 전체 흐름

  - ① 도메인 이벤트 발행 (VinylLiked/ReviewChanged)
  - ② Producer (AFTER_COMMIT → XADD)
  - ③ Consumer (Consumer Group + 수동 ACK)
  - ④ ZINCRBY 집계
  - ⑤ 멱등성 (SETNX + eventId)
  - ⑥ 랭킹 API (ZREVRANGE + DB 정보)


## 💫 타입

- [x] 기능
- [ ] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [x] 문서 수정
- [ ] 기타(환경) 
- [x] 테스트 
